### PR TITLE
add wallet signer class

### DIFF
--- a/src/walletSdk/Anchor/index.ts
+++ b/src/walletSdk/Anchor/index.ts
@@ -24,7 +24,7 @@ export class Anchor {
 
   async auth() {
     const tomlInfo = await this.getInfo();
-    return new Auth(tomlInfo.webAuthEndpoint, this.httpClient);
+    return new Auth(this.cfg, tomlInfo.webAuthEndpoint, this.httpClient);
   }
 
   interactive() {

--- a/src/walletSdk/Auth/WalletSigner.ts
+++ b/src/walletSdk/Auth/WalletSigner.ts
@@ -1,4 +1,19 @@
-// TODO - https://stellarorg.atlassian.net/browse/WAL-813?atlOrigin=eyJpIjoiODBkZTQ1MDMzYTJmNDFjOWI0NDM3MTQ2YWYxNTEzNTgiLCJwIjoiaiJ9
+import StellarSdk, { Keypair, Transaction } from "stellar-sdk";
 
-export interface WalletSigner {}
-export const DefaultSigner: WalletSigner = {};
+export interface WalletSigner {
+  signWithClientAccount(txn: Transaction, account: Keypair): Transaction;
+  signWithDomainAccount(
+    transactionXDR: string,
+    networkPassPhrase: string,
+    account: Keypair
+  ): Transaction;
+}
+export const DefaultSigner: WalletSigner = {
+  signWithClientAccount: (txn, account) => {
+    txn.sign(account);
+    return txn;
+  },
+  signWithDomainAccount: (transactionXDR, networkPassPhrase, account) => {
+    throw new Error("The DefaultSigner can't sign transactions with domain");
+  },
+};

--- a/src/walletSdk/Auth/index.ts
+++ b/src/walletSdk/Auth/index.ts
@@ -38,7 +38,11 @@ export class Auth {
     return await this.getToken(signedTx);
   }
 
-  async challenge(accountKp: Keypair, memoId?: string, clientDomain?: string) {
+  private async challenge(
+    accountKp: Keypair,
+    memoId?: string,
+    clientDomain?: string
+  ) {
     if (memoId && parseInt(memoId) < 0) {
       throw new InvalidMemoError();
     }
@@ -56,7 +60,7 @@ export class Auth {
     }
   }
 
-  sign(
+  private sign(
     accountKp: Keypair,
     challengeResponse: {
       transaction: string;
@@ -84,7 +88,7 @@ export class Auth {
     return transaction;
   }
 
-  async getToken(signedTx) {
+  private async getToken(signedTx) {
     try {
       const resp = await this.httpClient.post(this.webAuthEndpoint, {
         transaction: signedTx.toXDR(),

--- a/src/walletSdk/Auth/index.ts
+++ b/src/walletSdk/Auth/index.ts
@@ -5,19 +5,23 @@ import {
   ClientDomainWithMemoError,
   ServerRequestFailedError,
 } from "../exception";
+import { WalletSigner } from "./WalletSigner";
 
 // Do not create this object directly, use the Wallet class.
 export class Auth {
+  private cfg;
   private webAuthEndpoint = "";
   private httpClient;
 
-  constructor(webAuthEndpoint, httpClient) {
+  constructor(cfg, webAuthEndpoint, httpClient) {
+    this.cfg = cfg;
     this.webAuthEndpoint = webAuthEndpoint;
     this.httpClient = httpClient;
   }
 
   async authenticate(
     accountKp: Keypair,
+    walletSigner?: WalletSigner,
     memoId?: string,
     clientDomain?: string
   ) {
@@ -28,8 +32,8 @@ export class Auth {
     );
     const signedTx = this.sign(
       accountKp,
-      challengeResponse.transaction,
-      challengeResponse.network_passphrase
+      challengeResponse,
+      walletSigner ?? this.cfg.app.defaultSigner
     );
     return await this.getToken(signedTx);
   }
@@ -52,13 +56,31 @@ export class Auth {
     }
   }
 
-  // TODO - add signing with client account functionality
-  sign(accountKp: Keypair, challengeTx, network) {
-    const transaction = StellarSdk.TransactionBuilder.fromXDR(
-      challengeTx,
-      network
+  sign(
+    accountKp: Keypair,
+    challengeResponse: {
+      transaction: string;
+      network_passphrase: string;
+    },
+    walletSigner: WalletSigner
+  ) {
+    let transaction = StellarSdk.TransactionBuilder.fromXDR(
+      challengeResponse.transaction,
+      challengeResponse.network_passphrase
     );
-    transaction.sign(accountKp);
+
+    // check if verifying client domain as well
+    for (const op of transaction.operations) {
+      if (op.type === "manageData" && op.name === "client_domain") {
+        transaction = walletSigner.signWithDomainAccount(
+          challengeResponse.transaction,
+          challengeResponse.network_passphrase,
+          accountKp
+        );
+      }
+    }
+
+    walletSigner.signWithClientAccount(transaction, accountKp);
     return transaction;
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -81,6 +81,7 @@ describe("Anchor", () => {
       },
     };
 
+    // because using dummy sk and not real demo wallet sk, lets just check that signing is called
     const challengeResponse = await auth.challenge(
       accountKp,
       "",


### PR DESCRIPTION
[ticket](https://stellarorg.atlassian.net/browse/WAL-813)

mimicking how the [kotlin-sdk](https://github.com/stellar/kotlin-wallet-sdk/blob/7ef34b4c3d3cae84109c806bc92c9a9fb10cbf68/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/WalletSigner.kt#L10) is handling wallet signing. Creating a generic interface that the user uses to handle signing with client and optional domain account. An example how it can be used is in the test