### PR TITLE
Add language support

### DIFF
--- a/src/walletSdk/Anchor/index.ts
+++ b/src/walletSdk/Anchor/index.ts
@@ -62,13 +62,13 @@ export class Anchor {
     return new Interactive(this.homeDomain, this);
   }
 
-  async getServicesInfo() {
+  async getServicesInfo(lang: string = this.language) {
     const toml = await this.getInfo();
     const transferServerEndpoint = toml.transferServerSep24;
 
     try {
       // TODO - use httpClient
-      const resp = await axios.get(`${transferServerEndpoint}/info`, {
+      const resp = await axios.get(`${transferServerEndpoint}/info?lang=${lang}`, {
         headers: {
           "Content-Type": "application/json",
         },

--- a/src/walletSdk/index.ts
+++ b/src/walletSdk/index.ts
@@ -10,9 +10,9 @@ import { getUrlDomain } from "./util/url";
 // TODO - https://stellarorg.atlassian.net/browse/WAL-789?atlOrigin=eyJpIjoiZjcwNzZhOTJmNjE1NGRhNTk1NDlkOTExMTYxMDJkZmYiLCJwIjoiaiJ9
 interface ClientConfigFn {}
 interface ClientConfig {}
-class HttpClient {}
+export class HttpClient {}
 
-class Config {
+export class Config {
   app: ApplicationConfiguration;
   stellar: StellarConfiguration;
   constructor(stellarCfg, appCfg) {
@@ -24,6 +24,7 @@ class Config {
 export class Wallet {
   private cfg: Config;
   private clients = [];
+  private language: string;
 
   static TestNet = (): Wallet => {
     return new Wallet(StellarConfiguration.TestNet());
@@ -35,19 +36,28 @@ export class Wallet {
 
   constructor(
     stellarConfiguration: StellarConfiguration,
-    applicationConfiguration: ApplicationConfiguration = new ApplicationConfiguration()
+    applicationConfiguration: ApplicationConfiguration = new ApplicationConfiguration(),
+    // Defaults wallet language to "en", this will reflect in all Anchor API calls
+    language: string = "en",
   ) {
     this.cfg = new Config(stellarConfiguration, applicationConfiguration);
+    this.language = language;
   }
 
-  anchor(homeDomain: string, httpClientConfig: ClientConfigFn = null) {
+  anchor(
+    homeDomain: string, 
+    httpClientConfig: ClientConfigFn = null,
+    language: string = this.language,
+  ) {
     const url =
       homeDomain.indexOf("://") !== -1 ? homeDomain : `https://${homeDomain}`;
-    return new Anchor(
-      this.cfg,
-      getUrlDomain(url),
-      this.getClient(httpClientConfig)
-    );
+
+    return new Anchor({
+        cfg: this.cfg,
+        homeDomain: getUrlDomain(url),
+        httpClient: this.getClient(httpClientConfig),
+        language,
+    });
   }
 
   stellar() {

--- a/src/walletSdk/interactive/index.ts
+++ b/src/walletSdk/interactive/index.ts
@@ -4,7 +4,7 @@ import { Anchor } from "../Anchor";
 import { AssetNotSupportedError, ServerRequestFailedError } from "../exception";
 
 // Extra fields should be sent as snake_case keys
-// since the SEP api uses that format for all params
+// since the SEP api spec uses that format for all params
 type ExtraFields = {
   [api_key: string]: string;
 };

--- a/src/walletSdk/interactive/index.ts
+++ b/src/walletSdk/interactive/index.ts
@@ -25,10 +25,10 @@ export enum FLOW_TYPE {
 
 // Do not create this object directly, use the Wallet class.
 export class Interactive {
-  private homeDomain = "";
-  private anchor: Anchor = null;
-
-  constructor(homeDomain, anchor) {
+  private homeDomain: string;
+  private anchor: Anchor;
+  
+  constructor(homeDomain: string, anchor: Anchor) {
     this.homeDomain = homeDomain;
     this.anchor = anchor;
   }
@@ -46,7 +46,7 @@ export class Interactive {
       accountAddress,
       assetCode,
       authToken,
-      lang = "en",
+      lang = this.anchor.language,
       extraFields,
       fundsAccountAddress = accountAddress,
       type,

--- a/src/walletSdk/interactive/index.ts
+++ b/src/walletSdk/interactive/index.ts
@@ -7,6 +7,14 @@ type ExtraFields = {
   [key: string]: string;
 };
 
+type InteractiveParams = {
+  accountAddress: string,
+  assetCode: string,
+  authToken: string,
+  extraFields?: ExtraFields,
+  fundsAccountAddress?: string
+};
+
 export enum FLOW_TYPE {
   DEPOSIT = "deposit",
   WITHDRAW = "withdraw",
@@ -22,48 +30,24 @@ export class Interactive {
     this.anchor = anchor;
   }
 
-  async deposit(
-    accountAddress: string,
-    assetCode: string,
-    authToken: string,
-    extraFields?: ExtraFields,
-    fundsAccountAddress?: string
-  ) {
-    return await this.flow(
+  async deposit(params: InteractiveParams) {
+    return await this.flow({ ...params, type: FLOW_TYPE.DEPOSIT });
+  }
+
+  async withdraw(params: InteractiveParams) {
+    return await this.flow({ ...params, type: FLOW_TYPE.WITHDRAW });
+  }
+
+  async flow(params: InteractiveParams & { type: FLOW_TYPE }) {
+    const {
       accountAddress,
       assetCode,
       authToken,
-      FLOW_TYPE.DEPOSIT,
       extraFields,
-      fundsAccountAddress
-    );
-  }
+      fundsAccountAddress = accountAddress,
+      type,
+    } = params;
 
-  async withdraw(
-    accountAddress: string,
-    assetCode: string,
-    authToken: string,
-    extraFields?: ExtraFields,
-    fundsAccountAddress?: string
-  ) {
-    return await this.flow(
-      accountAddress,
-      assetCode,
-      authToken,
-      FLOW_TYPE.WITHDRAW,
-      extraFields,
-      fundsAccountAddress
-    );
-  }
-
-  async flow(
-    accountAddress: string,
-    assetCode: string,
-    authToken: string,
-    type: string,
-    extraFields?: ExtraFields,
-    fundsAccountAddress?: string
-  ) {
     const toml = await this.anchor.getInfo();
     const transferServerEndpoint = toml.transferServerSep24;
 
@@ -84,7 +68,7 @@ export class Interactive {
         `${transferServerEndpoint}/transactions/${type}/interactive`,
         {
           asset_code: assetCode,
-          account: fundsAccountAddress ? fundsAccountAddress : accountAddress,
+          account: fundsAccountAddress,
           ...extraFields,
         },
         {

--- a/src/walletSdk/interactive/index.ts
+++ b/src/walletSdk/interactive/index.ts
@@ -3,16 +3,19 @@ import axios from "axios";
 import { Anchor } from "../Anchor";
 import { AssetNotSupportedError, ServerRequestFailedError } from "../exception";
 
+// Extra fields should be sent as snake_case keys
+// since the SEP api uses that format for all params
 type ExtraFields = {
-  [key: string]: string;
+  [api_key: string]: string;
 };
 
 type InteractiveParams = {
-  accountAddress: string,
-  assetCode: string,
-  authToken: string,
-  extraFields?: ExtraFields,
-  fundsAccountAddress?: string
+  accountAddress: string;
+  assetCode: string;
+  authToken: string;
+  lang?: string;
+  extraFields?: ExtraFields;
+  fundsAccountAddress?: string;
 };
 
 export enum FLOW_TYPE {
@@ -43,6 +46,7 @@ export class Interactive {
       accountAddress,
       assetCode,
       authToken,
+      lang = "en",
       extraFields,
       fundsAccountAddress = accountAddress,
       type,
@@ -68,6 +72,7 @@ export class Interactive {
         `${transferServerEndpoint}/transactions/${type}/interactive`,
         {
           asset_code: assetCode,
+          lang,
           account: fundsAccountAddress,
           ...extraFields,
         },

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import StellarSdk, { Keypair } from "stellar-sdk";
+import { Keypair } from "stellar-sdk";
 
 import sdk from "../src";
 import { ServerRequestFailedError } from "../src/walletSdk/exception";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,7 +57,16 @@ describe("Anchor", () => {
     const assetCode = "SRT";
     const resp = await anchor
       .interactive()
-      .deposit({ accountAddress: accountKp.publicKey(), assetCode, authToken });
+      .deposit({ 
+        accountAddress: accountKp.publicKey(), 
+        assetCode, 
+        authToken,
+        lang: "en-US",
+        extraFields:{
+          wallet_name: "Test Wallet",
+          wallet_url: "https://stellar.org/",
+        },
+      });
 
     expect(resp.url).toBeTruthy();
     expect(resp.id).toBeTruthy();
@@ -67,7 +76,16 @@ describe("Anchor", () => {
     const assetCode = "SRT";
     const resp = await anchor
       .interactive()
-      .withdraw({ accountAddress: accountKp.publicKey(), assetCode, authToken });
+      .withdraw({ 
+        accountAddress: accountKp.publicKey(), 
+        assetCode, 
+        authToken,
+        lang: "en-US",
+        extraFields:{
+          wallet_name: "Test Wallet",
+          wallet_url: "https://stellar.org/",
+        },
+      });
 
     expect(resp.url).toBeTruthy();
     expect(resp.id).toBeTruthy();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,7 +57,7 @@ describe("Anchor", () => {
     const assetCode = "SRT";
     const resp = await anchor
       .interactive()
-      .deposit(accountKp.publicKey(), assetCode, authToken);
+      .deposit({ accountAddress: accountKp.publicKey(), assetCode, authToken });
 
     expect(resp.url).toBeTruthy();
     expect(resp.id).toBeTruthy();
@@ -67,7 +67,7 @@ describe("Anchor", () => {
     const assetCode = "SRT";
     const resp = await anchor
       .interactive()
-      .withdraw(accountKp.publicKey(), assetCode, authToken);
+      .withdraw({ accountAddress: accountKp.publicKey(), assetCode, authToken });
 
     expect(resp.url).toBeTruthy();
     expect(resp.id).toBeTruthy();


### PR DESCRIPTION
Related: [[TS] Add lang support for all Sep-24 endpoints](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?modal=detail&selectedIssue=WAL-837)

This PR adds `language` support to the Wallet (and Anchor) class which should be used as default `lang` param value for all Sep-24 API calls.

Devs can still optionally set the `lang` parameter individually per function.