### PR TITLE
Add getHistory function

### DIFF
--- a/src/walletSdk/exception/index.ts
+++ b/src/walletSdk/exception/index.ts
@@ -1,13 +1,13 @@
 export class ServerRequestFailedError extends Error {
     constructor(e) {
-        super(`server request failed with error: ${e}`);
+        super(`Server request failed with error: ${e}`);
         Object.setPrototypeOf(this, ServerRequestFailedError.prototype);
     }
 }
 
 export class AssetNotSupportedError extends Error {
     constructor(type, assetCode) {
-        super(`asset ${assetCode} not supported for ${type}`);
+        super(`Asset ${assetCode} not supported` + (type ? ` for ${type}` : ""));
         Object.setPrototypeOf(this, AssetNotSupportedError.prototype);
     }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -3,7 +3,7 @@ import http from "http";
 import sinon from "sinon";
 
 import sdk from "../src";
-import { ServerRequestFailedError } from "../src/walletSdk/exception";
+import { AssetNotSupportedError, ServerRequestFailedError } from "../src/walletSdk/exception";
 import {
   TransactionStatus,
   WatcherResponse,
@@ -245,6 +245,57 @@ describe("Anchor", () => {
         pagingId: "randomPagingId",
       });
     }).rejects.toThrowError(ServerRequestFailedError);
+  });
+
+  it("should fetch only finished transactions", async () => {
+    // mock TOML response to include the "SRT" currency
+    jest
+      .spyOn(anchor, "getInfo")
+      .mockResolvedValue({
+        networkPassphrase: 'Test SDF Network ; September 2015',
+        transferServerSep24: 'https://testanchor.stellar.org/sep24',
+        webAuthEndpoint: 'https://testanchor.stellar.org/auth',
+        accounts: [
+          'GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE',
+          'GDRND2IUXVMHZ4XTB2RZ4AJ3AOLON3WTAOC23XEASB56NHDFW3ED57TW'
+        ],
+        documentation: {
+          orgName: 'Stellar Development Foundation',
+          orgUrl: 'https://stellar.org',
+          orgGithub: 'stellar',
+        },
+        principals: [],
+        currencies: [{ code: "SRT" }, { code: "USDC" }],
+        validators: []
+      });
+
+    // mock transactions response so we have a few completed/refunded
+    jest
+      .spyOn(anchor, "getTransactionsForAsset")
+      .mockResolvedValue(TransactionsResponse);
+
+    const transactions = await anchor.getHistory({
+      authToken,
+      assetCode: "SRT",
+    });
+
+    expect(transactions.length).toBeGreaterThan(0);
+
+    transactions.forEach(({ status }) => {
+      expect([
+        TransactionStatus.completed, 
+        TransactionStatus.refunded
+      ].includes(status)).toBeTruthy();
+    });
+  });
+
+  it("should error fetching history for unsupported asset", async () => {
+    await expect(async () => {
+      await anchor.getHistory({
+        authToken,
+        assetCode: "ABC",
+      });
+    }).rejects.toThrowError(AssetNotSupportedError);
   });
 
   describe("watchAllTransactions", () => {


### PR DESCRIPTION
Related: [[TS] SEP-24: Query](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?modal=detail&selectedIssue=WAL-788)

This PR ports the [getHistory](https://github.com/stellar/kotlin-wallet-sdk/blob/main/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/anchor/Anchor.kt#L170) function from Kotlin's SDK.

It should basically return only completed/refunded transactions and throw an error in case asset is not supported.