### PR TITLE
add homedomain

### DIFF
--- a/src/walletSdk/Anchor/index.ts
+++ b/src/walletSdk/Anchor/index.ts
@@ -69,7 +69,12 @@ export class Anchor {
 
   async auth(): Promise<Auth> {
     const tomlInfo = await this.getInfo();
-    return new Auth(this.cfg, tomlInfo.webAuthEndpoint, this.httpClient);
+    return new Auth(
+      this.cfg,
+      tomlInfo.webAuthEndpoint,
+      this.homeDomain,
+      this.httpClient
+    );
   }
 
   interactive(): Interactive {

--- a/src/walletSdk/Auth/index.ts
+++ b/src/walletSdk/Auth/index.ts
@@ -11,11 +11,13 @@ import { WalletSigner } from "./WalletSigner";
 export class Auth {
   private cfg;
   private webAuthEndpoint = "";
+  private homeDomain;
   private httpClient;
 
-  constructor(cfg, webAuthEndpoint, httpClient) {
+  constructor(cfg, webAuthEndpoint, homeDomain, httpClient) {
     this.cfg = cfg;
     this.webAuthEndpoint = webAuthEndpoint;
+    this.homeDomain = homeDomain;
     this.httpClient = httpClient;
   }
 
@@ -51,7 +53,9 @@ export class Auth {
     }
     const url = `${this.webAuthEndpoint}?account=${accountKp.publicKey()}${
       memoId ? `&memo=${memoId}` : ""
-    }${clientDomain ? `&client_domain=${clientDomain}` : ""}`;
+    }${clientDomain ? `&client_domain=${clientDomain}` : ""}${
+      this.homeDomain ? `&home_domain=${this.homeDomain}` : ""
+    }`;
     try {
       const auth = await this.httpClient.get(url);
       return auth.data;


### PR DESCRIPTION
after reviewing Sep-10 code for [ticket](https://stellarorg.atlassian.net/browse/WAL-886?atlOrigin=eyJpIjoiMTE5NjM1MTJlZGI4NDdiNzliZDRkYmJlOGNjOWZmYjMiLCJwIjoiaiJ9) , the optional home_domain param wasn't added yet, so adding that here

it's automatically included in the challengeTxn url similar to the [kotlin sdk](https://github.com/stellar/kotlin-wallet-sdk/blob/7536849329ef645a9ecee4c16b89dade1d6867c4/wallet-sdk/src/main/kotlin/org/stellar/walletsdk/auth/Auth.kt#L74)