### PR TITLE
use AccountKeypair in sdk

### DIFF
--- a/src/walletSdk/Auth/WalletSigner.ts
+++ b/src/walletSdk/Auth/WalletSigner.ts
@@ -19,7 +19,7 @@ export interface WalletSigner {
 
 export const DefaultSigner: WalletSigner = {
   signWithClientAccount: ({ transaction, accountKp }) => {
-    transaction.sign(accountKp);
+    transaction.sign(accountKp.keypair);
     return transaction;
   },
   signWithDomainAccount: () => {

--- a/src/walletSdk/Auth/WalletSigner.ts
+++ b/src/walletSdk/Auth/WalletSigner.ts
@@ -1,20 +1,20 @@
 import { Transaction } from "stellar-sdk";
-import { 
-  SignWithClientAccountParams, 
-  SignWithDomainAccountParams 
+import {
+  SignWithClientAccountParams,
+  SignWithDomainAccountParams,
 } from "../Types";
 
 export interface WalletSigner {
-  signWithClientAccount({ 
-    transaction, 
-    accountKp 
+  signWithClientAccount({
+    transaction,
+    accountKp,
   }: SignWithClientAccountParams): Transaction;
 
   signWithDomainAccount({
     transactionXDR,
     networkPassphrase,
-    accountKp
-  }: SignWithDomainAccountParams): Transaction;
+    accountKp,
+  }: SignWithDomainAccountParams): Promise<Transaction>;
 }
 
 export const DefaultSigner: WalletSigner = {
@@ -22,7 +22,9 @@ export const DefaultSigner: WalletSigner = {
     transaction.sign(accountKp.keypair);
     return transaction;
   },
-  signWithDomainAccount: () => {
-    throw new Error("The DefaultSigner can't sign transactions with domain account");
+  signWithDomainAccount: async () => {
+    throw new Error(
+      "The DefaultSigner can't sign transactions with domain account"
+    );
   },
 };

--- a/src/walletSdk/Auth/WalletSigner.ts
+++ b/src/walletSdk/Auth/WalletSigner.ts
@@ -1,13 +1,13 @@
 import { Transaction } from "stellar-sdk";
-import {
-  SignWithClientAccountParams,
-  SignWithDomainAccountParams,
+import { 
+  SignWithClientAccountParams, 
+  SignWithDomainAccountParams 
 } from "../Types";
 
 export interface WalletSigner {
-  signWithClientAccount({
-    transaction,
-    accountKp,
+  signWithClientAccount({ 
+    transaction, 
+    accountKp 
   }: SignWithClientAccountParams): Transaction;
 
   signWithDomainAccount({

--- a/src/walletSdk/Auth/index.ts
+++ b/src/walletSdk/Auth/index.ts
@@ -7,11 +7,11 @@ import {
   ClientDomainWithMemoError,
   ServerRequestFailedError,
 } from "../Exceptions";
-import {
-  AuthenticateParams,
-  AuthToken,
-  ChallengeParams,
-  ChallengeResponse,
+import { 
+  AuthenticateParams, 
+  AuthToken, 
+  ChallengeParams, 
+  ChallengeResponse, 
   SignParams,
 } from "../Types";
 
@@ -34,7 +34,12 @@ export class Auth {
   private httpClient: AxiosInstance;
 
   constructor(params: AuthParams) {
-    const { cfg, webAuthEndpoint, homeDomain, httpClient } = params;
+    const {
+      cfg,
+      webAuthEndpoint,
+      homeDomain,
+      httpClient,
+    } = params;
 
     this.cfg = cfg;
     this.webAuthEndpoint = webAuthEndpoint;
@@ -51,12 +56,12 @@ export class Auth {
     const challengeResponse = await this.challenge({
       accountKp,
       memoId,
-      clientDomain,
+      clientDomain
     });
     const signedTransaction = await this.sign({
       accountKp,
       challengeResponse,
-      walletSigner: walletSigner ?? this.cfg.app.defaultSigner,
+      walletSigner: walletSigner ?? this.cfg.app.defaultSigner
     });
     return this.getToken(signedTransaction);
   }
@@ -97,14 +102,14 @@ export class Auth {
       challengeResponse.transaction,
       challengeResponse.network_passphrase
     );
-
+      
     // check if verifying client domain as well
     for (const op of transaction.operations) {
       if (op.type === "manageData" && op.name === "client_domain") {
         transaction = await walletSigner.signWithDomainAccount({
           transactionXDR: challengeResponse.transaction,
           networkPassphrase: challengeResponse.network_passphrase,
-          accountKp,
+          accountKp
         });
       }
     }

--- a/src/walletSdk/Auth/index.ts
+++ b/src/walletSdk/Auth/index.ts
@@ -77,7 +77,9 @@ export class Auth {
     if (clientDomain && memoId) {
       throw new ClientDomainWithMemoError();
     }
-    const url = `${this.webAuthEndpoint}?account=${accountKp.publicKey()}${
+    const url = `${
+      this.webAuthEndpoint
+    }?account=${accountKp.keypair.publicKey()}${
       memoId ? `&memo=${memoId}` : ""
     }${clientDomain ? `&client_domain=${clientDomain}` : ""}${
       this.homeDomain ? `&home_domain=${this.homeDomain}` : ""

--- a/src/walletSdk/Horizon/Account.ts
+++ b/src/walletSdk/Horizon/Account.ts
@@ -1,6 +1,6 @@
 import { Keypair, Transaction, FeeBumpTransaction } from "stellar-sdk";
 
-class AccountKeypair {
+export class AccountKeypair {
   keypair: Keypair;
   constructor(keypair: Keypair) {
     this.keypair = keypair;

--- a/src/walletSdk/Types/auth.ts
+++ b/src/walletSdk/Types/auth.ts
@@ -1,20 +1,21 @@
 import { Keypair, Transaction } from "stellar-sdk";
 import { WalletSigner } from "../Auth/WalletSigner";
+import { AccountKeypair } from "../Horizon/Account";
 
 export type AuthenticateParams = {
-  accountKp: Keypair;
+  accountKp: AccountKeypair;
   walletSigner?: WalletSigner;
   memoId?: string;
   clientDomain?: string;
-}
+};
 
 export type AuthToken = string;
 
 export type ChallengeParams = {
-  accountKp: Keypair;
+  accountKp: AccountKeypair;
   memoId?: string;
   clientDomain?: string;
-}
+};
 
 export type XdrEncodedTransaction = string;
 export type NetworkPassphrase = string;
@@ -22,21 +23,21 @@ export type NetworkPassphrase = string;
 export type ChallengeResponse = {
   transaction: XdrEncodedTransaction;
   network_passphrase: NetworkPassphrase;
-}
+};
 
 export type SignParams = {
-  accountKp: Keypair;
+  accountKp: AccountKeypair;
   challengeResponse: ChallengeResponse;
   walletSigner: WalletSigner;
-}
+};
 
 export type SignWithClientAccountParams = {
   transaction: Transaction;
-  accountKp: Keypair;
-}
+  accountKp: AccountKeypair;
+};
 
 export type SignWithDomainAccountParams = {
   transactionXDR: XdrEncodedTransaction;
   networkPassphrase: NetworkPassphrase;
-  accountKp: Keypair;
-}
+  accountKp: AccountKeypair;
+};

--- a/src/walletSdk/Types/index.ts
+++ b/src/walletSdk/Types/index.ts
@@ -11,13 +11,11 @@ export type WalletParams = {
 
 export type WalletAnchor = {
   homeDomain: string;
-  httpClientConfig?: AxiosRequestConfig;
   language?: string;
 };
 
 export type WalletRecovery = {
   servers: Server[]; 
-  httpClientConfig?: AxiosRequestConfig;
 };
 
 export type ConfigParams = { 

--- a/src/walletSdk/index.ts
+++ b/src/walletSdk/index.ts
@@ -59,7 +59,7 @@ export class Wallet {
     return new Anchor({
       cfg: this.cfg,
       homeDomain: getUrlDomain(url),
-      httpClient: this.getClient(httpClientConfig),
+      httpClient: this.cfg.app.defaultClient,
       language,
     });
   }
@@ -75,18 +75,8 @@ export class Wallet {
     return new Recovery({
       cfg: this.cfg,
       stellar: this.stellar(),
-      httpClient: this.getClient(httpClientConfig),
+      httpClient: this.cfg.app.defaultClient,
       servers
-    });
-  }
-
-  getClient(httpClientConfig: AxiosRequestConfig = {}): AxiosInstance {
-    return axios.create({
-      headers: {
-        ...walletHeaders,
-        ...httpClientConfig.headers,
-      },
-      ...httpClientConfig,
     });
   }
 }
@@ -138,17 +128,18 @@ export class StellarConfiguration {
   }
 }
 
+export const DefaultClient = axios.create({
+  headers: {
+    ...walletHeaders,
+  },
+});
 
 export class ApplicationConfiguration {
   defaultSigner: WalletSigner;
   defaultClient: AxiosInstance;
 
-  constructor(defaultSigner: WalletSigner = DefaultSigner) {
-    this.defaultSigner = defaultSigner;
-    this.defaultClient = axios.create({
-      headers: {
-        ...walletHeaders,
-      },
-    });
+  constructor(defaultSigner?: WalletSigner, defaultClient?: AxiosInstance) {
+    this.defaultSigner = defaultSigner || DefaultSigner;
+    this.defaultClient = defaultClient || DefaultClient;
   }
 }

--- a/src/walletSdk/index.ts
+++ b/src/walletSdk/index.ts
@@ -48,11 +48,7 @@ export class Wallet {
     this.language = language;
   }
 
-  anchor({
-    homeDomain,
-    httpClientConfig = {},
-    language = this.language
-  }: WalletAnchor): Anchor {
+  anchor({ homeDomain, language = this.language }: WalletAnchor): Anchor {
     const url =
       homeDomain.indexOf("://") !== -1 ? homeDomain : `https://${homeDomain}`;
 
@@ -68,10 +64,7 @@ export class Wallet {
     return new Stellar(this.cfg);
   }
 
-  recovery({ 
-    servers, 
-    httpClientConfig = {} 
-  }: WalletRecovery): Recovery {
+  recovery({ servers }: WalletRecovery): Recovery {
     return new Recovery({
       cfg: this.cfg,
       stellar: this.stellar(),

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -9,6 +9,7 @@ import { TransactionStatus } from "../src/walletSdk/Types";
 
 import { TransactionsResponse } from "../test/fixtures/TransactionsResponse";
 import { WalletSigner } from "../src/walletSdk/Auth/WalletSigner";
+import { SigningKeypair } from "../src/walletSdk/Horizon/Account";
 
 const originalSetTimeout = global.setTimeout;
 function sleep(time: number) {
@@ -53,7 +54,7 @@ describe("Anchor", () => {
   beforeEach(() => {
     const Wal = walletSdk.Wallet.TestNet();
     anchor = Wal.anchor({ homeDomain: "testanchor.stellar.org" });
-    accountKp = Keypair.fromSecret(
+    accountKp = SigningKeypair.fromSecret(
       "SDXC3OHSJZEQIXKEWFDNEZEQ7SW5DWBPW7RKUWI36ILY3QZZ6VER7TXV"
     );
   });
@@ -78,7 +79,7 @@ describe("Anchor", () => {
 
     const walletSigner: WalletSigner = {
       signWithClientAccount: ({ transaction, accountKp }) => {
-        transaction.sign(accountKp);
+        transaction.sign(accountKp.keypair);
         signedByClient = true;
         return transaction;
       },
@@ -117,7 +118,7 @@ describe("Anchor", () => {
   it("should give interactive deposit url", async () => {
     const assetCode = "SRT";
     const resp = await anchor.interactive().deposit({
-      accountAddress: accountKp.publicKey(),
+      accountAddress: accountKp.publicKey,
       assetCode,
       authToken,
       lang: "en-US",
@@ -134,7 +135,7 @@ describe("Anchor", () => {
   it("should give interactive withdraw url", async () => {
     const assetCode = "SRT";
     const resp = await anchor.interactive().withdraw({
-      accountAddress: accountKp.publicKey(),
+      accountAddress: accountKp.publicKey,
       assetCode,
       authToken,
       lang: "en-US",
@@ -153,7 +154,7 @@ describe("Anchor", () => {
 
     // creates new 'incomplete' deposit transaction
     const { id: transactionId } = await anchor.interactive().deposit({
-      accountAddress: accountKp.publicKey(),
+      accountAddress: accountKp.publicKey,
       assetCode,
       authToken,
     });

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -83,7 +83,7 @@ describe("Anchor", () => {
         signedByClient = true;
         return transaction;
       },
-      signWithDomainAccount: ({ transactionXDR, networkPassphrase, accountKp }) => {
+      signWithDomainAccount: async ({ transactionXDR, networkPassphrase, accountKp }) => {
         // dummy secret key for signing
         const clientDomainKp = Keypair.fromSecret(
           "SC7PKBRGRI5X4XP4QICBZ2NL67VUJJVKFKXDTGSPI3SQYZGC4NZWONIH"
@@ -103,7 +103,7 @@ describe("Anchor", () => {
       accountKp,
       clientDomain: "demo-wallet-server.stellar.org"
     });
-    const txn = auth.sign({ accountKp, challengeResponse, walletSigner });
+    const txn = await auth.sign({ accountKp, challengeResponse, walletSigner });
     expect(txn).toBeTruthy();
     expect(signedByClient).toBe(true);
     expect(signedByDomain).toBe(true);

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,6 +1,7 @@
 import StellarSdk, { Keypair } from "stellar-sdk";
 import http from "http";
 import sinon from "sinon";
+import axios, { AxiosInstance } from "axios";
 
 import sdk from "../src";
 import { AssetNotSupportedError, ServerRequestFailedError } from "../src/walletSdk/Exceptions";
@@ -8,7 +9,10 @@ import { Watcher } from "../src/walletSdk/Watcher";
 import { TransactionStatus } from "../src/walletSdk/Types";
 
 import { TransactionsResponse } from "../test/fixtures/TransactionsResponse";
-import { WalletSigner } from "../src/walletSdk/Auth/WalletSigner";
+import {
+  WalletSigner,
+  DefaultSigner
+} from "../src/walletSdk/Auth/WalletSigner";
 import { SigningKeypair } from "../src/walletSdk/Horizon/Account";
 
 const originalSetTimeout = global.setTimeout;
@@ -30,12 +34,20 @@ describe("Wallet", () => {
       stellarConfiguration: walletSdk.StellarConfiguration.TestNet(),
       applicationConfiguration: appConfig
     });
-
-    let client = wal.getClient();
-
-    // custom client
-    client = wal.getClient({
-      httpAgent: new http.Agent({ keepAlive: false }),
+  });
+  it("should be able to customize a client", async () => {
+    const customClient: AxiosInstance = axios.create({
+      baseURL: "https://some-url.com/api",
+      timeout: 1000,
+      headers: { "X-Custom-Header": "foobar" },
+    });
+    let appConfig = new walletSdk.ApplicationConfiguration(
+      DefaultSigner,
+      customClient
+    );
+    let wal = new walletSdk.Wallet({
+      stellarConfiguration: walletSdk.StellarConfiguration.TestNet(),
+      applicationConfiguration: appConfig,
     });
   });
 });
@@ -1709,8 +1721,7 @@ describe("Http client", () => {
     const accountKp = Keypair.fromSecret(
       "SDXC3OHSJZEQIXKEWFDNEZEQ7SW5DWBPW7RKUWI36ILY3QZZ6VER7TXV"
     );
-    const wal = walletSdk.Wallet.TestNet();
-    const client = wal.getClient();
+    const client = walletSdk.DefaultClient;
 
     const resp = await client.get(
       `http://testanchor.stellar.org/auth?account=${accountKp.publicKey()}`


### PR DESCRIPTION
when adding docs in https://github.com/stellar/typescript-wallet-sdk/pull/25 noticed 3 changes need to be made:
1. use `AccountKeypair` instead of the stellar-sdk Keypair class
2. WalletSigner.signWithDomainAccount needs to be async since meant to contain a backend call
3. be able to pass in a custom defined client