### PR TITLE
[Horizon/AccountService] Add getInfo and getHistory functions

### DIFF
--- a/src/walletSdk/Exceptions/index.ts
+++ b/src/walletSdk/Exceptions/index.ts
@@ -120,3 +120,10 @@ export class SignerRequiredError extends Error {
     Object.setPrototypeOf(this, SignerRequiredError.prototype);
   }
 }
+
+export class OperationsLimitExceededError extends Error {
+  constructor(maxLimit: number) {
+    super(`Maximum limit is ${maxLimit} operations`);
+    Object.setPrototypeOf(this, OperationsLimitExceededError.prototype);
+  }
+}

--- a/src/walletSdk/Horizon/AccountService.ts
+++ b/src/walletSdk/Horizon/AccountService.ts
@@ -1,7 +1,9 @@
-import { Keypair, Networks, Server } from "stellar-sdk";
+import { Keypair, Networks, Server, ServerApi } from "stellar-sdk";
 
 import { Config } from "walletSdk";
 import { SigningKeypair } from "./Account";
+import { HORIZON_LIMIT_DEFAULT, HORIZON_LIMIT_MAX, HORIZON_ORDER } from "../Types";
+import { OperationsLimitExceededError } from "../Exceptions";
 
 // Do not create this object directly, use the Wallet class.
 export class AccountService {
@@ -13,7 +15,68 @@ export class AccountService {
     this.network = cfg.stellar.network;
   }
 
+  /**
+   * Generate new account keypair (public and secret key). This key pair can be
+   * used to create a Stellar account.
+   *
+   * @return public key and secret key
+   */
   createKeypair(): SigningKeypair {
     return new SigningKeypair(Keypair.random());
+  }
+
+  /**
+   * Get account information from the Stellar network.
+   *
+   * @param accountAddress Stellar address of the account
+   * @param serverInstance optional Horizon server instance when default doesn't work
+   * @return account information
+   */
+  async getInfo({ 
+    accountAddress, 
+    serverInstance = this.server 
+  }: { 
+    accountAddress: string; 
+    serverInstance?: Server;
+  }): Promise<ServerApi.AccountRecord> {
+    return serverInstance.accounts().accountId(accountAddress).call();
+  }
+
+  /**
+   * Get account operations for the specified Stellar address.
+   *
+   * @param accountAddress Stellar address of the account
+   * @param limit optional how many operations to fetch, maximum is 200, default is 10
+   * @param order optional data order, ascending or descending, defaults to descending
+   * @param cursor optional cursor to specify a starting point
+   * @param includeFailed optional flag to include failed operations, defaults to false
+   * @return a list of operations
+   * @throws [OperationsLimitExceededException] when maximum limit of 200 is exceeded
+   */
+  async getHistory({
+    accountAddress,
+    limit = HORIZON_LIMIT_DEFAULT,
+    order = HORIZON_ORDER.DESC,
+    cursor,
+    includeFailed = false,
+  }: {
+    accountAddress: string;
+    limit?: number;
+    order?: HORIZON_ORDER;
+    cursor?: string;
+    includeFailed?: boolean;
+  }): Promise<ServerApi.CollectionPage<ServerApi.OperationRecord>> {
+    if (limit > HORIZON_LIMIT_MAX) {
+      throw new OperationsLimitExceededError(HORIZON_LIMIT_MAX);
+    }
+    
+    return this.server
+      .operations()
+      .forAccount(accountAddress)
+      .limit(limit)
+      .order(order)
+      .cursor(cursor)
+      .includeFailed(includeFailed)
+      .call();
   }
 }

--- a/src/walletSdk/Types/horizon.ts
+++ b/src/walletSdk/Types/horizon.ts
@@ -4,7 +4,7 @@ import { AccountKeypair } from "../Horizon/Account";
 export enum NETWORK_URLS {
   PUBLIC = "https://horizon.stellar.org",
   TESTNET = "https://horizon-testnet.stellar.org",
-}
+};
 
 export type TransactionParams = {
   sourceAddress: AccountKeypair;
@@ -22,4 +22,12 @@ export type SubmitWithFeeIncreaseParams = {
   baseFee?: number;
   memo?: Memo;
   maxFee?: number;
+};
+
+export const HORIZON_LIMIT_MAX = 200;
+export const HORIZON_LIMIT_DEFAULT = 10;
+
+export enum HORIZON_ORDER {
+  ASC = "asc",
+  DESC = "desc",
 };

--- a/test/account.test.ts
+++ b/test/account.test.ts
@@ -1,19 +1,11 @@
-import StellarSdk, {
-  TransactionBuilder,
-  Networks,
-  Server,
-  Keypair,
-  Memo,
-  MemoText,
-} from "stellar-sdk";
-import { PublicKeypair } from "../src/walletSdk/Horizon/Account";
+import { TransactionBuilder, Networks } from "stellar-sdk";
 
-import sdk from "../src";
-const { walletSdk } = sdk;
+import { Wallet } from "../src";
+import { PublicKeypair } from "../src/walletSdk/Horizon/Account";
 
 describe("Account", () => {
   it("should init keypair and sign", () => {
-    const wal = walletSdk.Wallet.TestNet();
+    const wal = Wallet.TestNet();
     const account = wal.stellar().account();
     const kp = account.createKeypair();
     expect(kp.publicKey).toBeTruthy();

--- a/test/accountService.test.ts
+++ b/test/accountService.test.ts
@@ -1,0 +1,100 @@
+import axios from "axios";
+import { Horizon } from "stellar-sdk";
+
+import { AccountService, SigningKeypair, Wallet } from "../src";
+import { HORIZON_ORDER } from "../src/walletSdk/Types";
+import { IssuedAssetId } from "../src/walletSdk/Asset";
+
+let accountService: AccountService;
+let accountAddress: string;
+
+describe("Horizon", () => {
+  // Creates testing stellar account with USDC trustline
+  // in case it doesn't exist just yet
+  beforeAll(async () => {
+    const wallet = Wallet.TestNet();
+    const stellar = wallet.stellar();
+    accountService = stellar.account();
+    
+    const fundingAccountKp = SigningKeypair.fromSecret(
+      "SDJTZXPFPWRK4GHECLQBDFRDCNEZFA4PIZA475WQEGKTL4Y2QLS77DGD",
+    );
+
+    // make sure funding account exists
+    try {
+      await stellar.server.loadAccount(fundingAccountKp.publicKey);
+    } catch (e) {
+      await axios.get("https://friendbot.stellar.org/?addr=" + fundingAccountKp.publicKey);
+    }
+
+    const testingAccountKp = SigningKeypair.fromSecret(
+      "SAXW2HC7JH5IJSIRFQ22JTMT6T3VONKGMYSIBLHNEJCV7AXLIGAXNESD"
+    );
+
+    // make sure testing account exists
+    accountAddress = testingAccountKp.publicKey;
+    try {
+      await stellar.server.loadAccount(accountAddress);
+    } catch (e) {
+      const txBuilder1 = await stellar.transaction({
+        sourceAddress: fundingAccountKp,
+        baseFee: 100,
+      });
+      const createAccTx = txBuilder1.createAccount(testingAccountKp, 2).build();
+      createAccTx.sign(fundingAccountKp.keypair);
+
+      let failed = false;
+      try {
+        await stellar.submitTransaction(createAccTx);
+        await stellar.server.loadAccount(accountAddress);
+      } catch (e) {
+        failed = true; 
+      }
+
+      const txBuilder2 = await stellar.transaction({
+        sourceAddress: testingAccountKp,
+        baseFee: 100,
+      });
+      const asset = new IssuedAssetId(
+        "USDC",
+        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      );
+      const addUsdcTx = txBuilder2.addAssetSupport(asset).build();
+      addUsdcTx.sign(testingAccountKp.keypair);
+
+      // make sure testing account has USDC trustline
+      try {
+        await stellar.submitTransaction(addUsdcTx);
+      } catch (e) {
+        failed = true; 
+      }
+
+      expect(failed).toBeFalsy();
+    }
+  }, 30000);
+
+  it("should return stellar account details", async () => {
+    const response  = await accountService.getInfo({ accountAddress });
+
+    expect(response.account_id).toBe(accountAddress);
+    expect(response.balances).toBeInstanceOf(Array);
+    expect(response.balances.some(
+      (balance) => (balance as Horizon.BalanceLineAsset).asset_code === "USDC"
+    )).toBeTruthy();
+  });
+
+  it("should return stellar account operations", async () => {
+    const response  = await accountService.getHistory({ 
+      accountAddress,
+      order: HORIZON_ORDER.ASC,
+    });
+
+    expect(response.records).toBeInstanceOf(Array);
+    expect(response.records[0]).toBeInstanceOf(Object);
+    expect(response.records[0]).toHaveProperty("id");
+    expect(response.records[0]).toHaveProperty("type");
+    expect(response.records[0]).toHaveProperty("created_at");
+    expect(response.records.some(({ type }) => type === "create_account")).toBeTruthy();
+    expect(response.records.some(({ type }) => type === "change_trust")).toBeTruthy();
+  });
+});

--- a/test/stellar.test.ts
+++ b/test/stellar.test.ts
@@ -1,11 +1,14 @@
-import StellarSdk, {
+import {
   Keypair,
   Memo,
   MemoText,
   Operation,
   Asset,
+  Horizon,
 } from "stellar-sdk";
 import axios from "axios";
+
+import { Stellar, Wallet } from "../src";
 import {
   AccountKeypair,
   SigningKeypair,
@@ -16,17 +19,14 @@ import {
   NativeAssetId,
 } from "../src/walletSdk/Asset";
 
-import sdk from "../src";
-const { walletSdk } = sdk;
-
-let wal;
-let stellar;
+let wal: Wallet;
+let stellar: Stellar;
 const kp = SigningKeypair.fromSecret(
   "SAS372GXRG6U7FW6W2PRVELKPOJG2FZZUADCIELWU2U3A45TNWXEQUV5",
 );
 describe("Stellar", () => {
-  beforeEach(() => {
-    wal = walletSdk.Wallet.TestNet();
+  beforeAll(() => {
+    wal = Wallet.TestNet();
     stellar = wal.stellar();
   });
   it("should create and submit a transaction", async () => {
@@ -69,7 +69,7 @@ describe("Stellar", () => {
       let failed;
       try {
         await stellar.submitTransaction(tx);
-        await stellar.server.loadAccount(param.sourceAddress.publicKey);
+        await stellar.server.loadAccount(newKp.publicKey);
       } catch (e) {
         failed = true;
       }
@@ -92,7 +92,7 @@ describe("Stellar", () => {
           },
         },
       })
-      .mockReturnValueOnce({ successful: true });
+      .mockReturnValueOnce(Promise.resolve(true));
 
     const txn = await stellar.submitWithFeeIncrease({
       sourceAddress: kp,
@@ -125,7 +125,7 @@ describe("Stellar", () => {
           },
         },
       })
-      .mockReturnValueOnce({ successful: true });
+      .mockReturnValueOnce(Promise.resolve(true));
 
     const signerFunction = (txn) => {
       txn.sign(kp.keypair);
@@ -134,11 +134,6 @@ describe("Stellar", () => {
 
     const txn = await stellar.submitWithFeeIncrease({
       sourceAddress: kp,
-      signingAddresses: [
-        SigningKeypair.fromSecret(
-          "SDCLCSOJ7JFDUAGMB4RD54JBQ633M2DHWWGNUE4WMK52WMEU6QKZCPHV",
-        ),
-      ],
       timeout: 180,
       baseFeeIncrease: 100,
       signerFunction,
@@ -153,6 +148,7 @@ describe("Stellar", () => {
     expect(txn).toBeTruthy();
     expect(txn.fee).toBe("200");
   });
+  
   it("should add and remove asset support", async () => {
     const asset = new IssuedAssetId(
       "USDC",
@@ -168,7 +164,7 @@ describe("Stellar", () => {
     await stellar.submitTransaction(tx);
 
     let acc = await stellar.server.loadAccount(kp.publicKey);
-    let balance = acc.balances.find((b) => b.asset_code === "USDC");
+    let balance = acc.balances.find((b) => (b as Horizon.BalanceLineAsset).asset_code === "USDC");
     expect(balance).toBeTruthy();
 
     const tx2 = txBuilder.removeAssetSupport(asset).build();
@@ -176,7 +172,7 @@ describe("Stellar", () => {
     await stellar.submitTransaction(tx2);
 
     acc = await stellar.server.loadAccount(kp.publicKey);
-    balance = acc.balances.find((b) => b.asset_code === "USDC");
+    balance = acc.balances.find((b) => (b as Horizon.BalanceLineAsset).asset_code === "USDC");
     expect(balance).toBeFalsy();
   }, 20000);
 

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -1,23 +1,17 @@
-import StellarSdk, { Keypair, Memo, MemoText } from "stellar-sdk";
-import http from "http";
-import sinon from "sinon";
 import axios, { AxiosInstance } from "axios";
+import sinon from "sinon";
+import StellarSdk, { Keypair, Memo, MemoText } from "stellar-sdk";
 
-import sdk from "../src";
-import {
-  AssetNotSupportedError,
-  ServerRequestFailedError,
-} from "../src/walletSdk/Exceptions";
+import { Anchor, ApplicationConfiguration, StellarConfiguration, Wallet } from "../src";
+import { DefaultClient } from "../src/walletSdk";
+import { ServerRequestFailedError } from "../src/walletSdk/Exceptions";
 import { Watcher } from "../src/walletSdk/Watcher";
 import { TransactionStatus, AnchorTransaction } from "../src/walletSdk/Types";
-
-import { TransactionsResponse } from "../test/fixtures/TransactionsResponse";
-import {
-  WalletSigner,
-  DefaultSigner,
-} from "../src/walletSdk/Auth/WalletSigner";
+import { WalletSigner, DefaultSigner } from "../src/walletSdk/Auth/WalletSigner";
 import { SigningKeypair } from "../src/walletSdk/Horizon/Account";
 import { Sep24 } from "../src/walletSdk/Anchor/Sep24";
+
+import { TransactionsResponse } from "../test/fixtures/TransactionsResponse";
 
 const originalSetTimeout = global.setTimeout;
 function sleep(time: number) {
@@ -26,16 +20,15 @@ function sleep(time: number) {
   });
 }
 
-const { walletSdk } = sdk;
 describe("Wallet", () => {
   it("should init", () => {
-    walletSdk.Wallet.TestNet();
-    walletSdk.Wallet.MainNet();
+    Wallet.TestNet();
+    Wallet.MainNet();
   });
   it("should be able return a client", async () => {
-    let appConfig = new walletSdk.ApplicationConfiguration();
-    let wal = new walletSdk.Wallet({
-      stellarConfiguration: walletSdk.StellarConfiguration.TestNet(),
+    let appConfig = new ApplicationConfiguration();
+    let wal = new Wallet({
+      stellarConfiguration: StellarConfiguration.TestNet(),
       applicationConfiguration: appConfig,
     });
   });
@@ -45,12 +38,12 @@ describe("Wallet", () => {
       timeout: 1000,
       headers: { "X-Custom-Header": "foobar" },
     });
-    let appConfig = new walletSdk.ApplicationConfiguration(
+    let appConfig = new ApplicationConfiguration(
       DefaultSigner,
       customClient,
     );
-    let wal = new walletSdk.Wallet({
-      stellarConfiguration: walletSdk.StellarConfiguration.TestNet(),
+    let wal = new Wallet({
+      stellarConfiguration: StellarConfiguration.TestNet(),
       applicationConfiguration: appConfig,
     });
   });
@@ -58,17 +51,17 @@ describe("Wallet", () => {
 
 describe("SEP-24 flow", () => {
   it("should init a wallet with network and domain", () => {
-    const Wal = walletSdk.Wallet.TestNet();
+    const Wal = Wallet.TestNet();
     Wal.anchor({ homeDomain: "anchor-domain" });
   });
 });
 
-let anchor;
-let accountKp;
-let authToken;
+let anchor: Anchor;
+let accountKp: SigningKeypair;
+let authToken: string;
 describe("Anchor", () => {
-  beforeEach(() => {
-    const Wal = walletSdk.Wallet.TestNet();
+  beforeAll(() => {
+    const Wal = Wallet.TestNet();
     anchor = Wal.anchor({ homeDomain: "testanchor.stellar.org" });
     accountKp = SigningKeypair.fromSecret(
       "SDXC3OHSJZEQIXKEWFDNEZEQ7SW5DWBPW7RKUWI36ILY3QZZ6VER7TXV",
@@ -89,7 +82,10 @@ describe("Anchor", () => {
   });
 
   it("should be able to authenticate with client domain", async () => {
-    const auth = await anchor.sep10();
+    // The Sep10.challenge and Sep10.sign functions are private so lint is
+    // complaining about it on a few lines below. So let's mock this auth
+    // instance as "any" to work around that.
+    const auth = await anchor.sep10() as any;
     let signedByClient = false;
     let signedByDomain = false;
 
@@ -191,7 +187,6 @@ describe("Anchor", () => {
 
     // creates new 'incomplete' deposit transaction
     const { id: transactionId } = await anchor.sep24().deposit({
-      accountAddress: accountKp.publicKey,
       assetCode,
       authToken,
     });
@@ -641,7 +636,7 @@ describe("Anchor", () => {
         id: "uyt1576b-ac28-4c02-a521-ddbfd9ae7oiu",
         kind: "deposit",
         status: TransactionStatus.completed,
-        status_eta: null,
+        status_eta: undefined,
         amount_in: "150.45",
         amount_out: "149.45",
         amount_fee: "1.00",
@@ -649,15 +644,15 @@ describe("Anchor", () => {
         completed_at: "2023-05-22T18:11:27.227597Z",
         stellar_transaction_id:
           "pokib2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9cbngt",
-        external_transaction_id: null,
+        external_transaction_id: undefined,
         more_info_url:
           "https://testanchor.stellar.org/sep24/transaction/more_info?id=uyt1576b-ac28-4c02-a521-ddbfd9ae7oiu",
         message: "deposit completed!",
-        claimable_balance_id: null,
+        claimable_balance_id: undefined,
         to: "GCZSYKPDWAKPGR7GYFBOIQB3TH352X7ELZL27WSJET5PDVFORDMGYTB5",
-        from: null,
+        from: undefined,
         deposit_memo_type: "hash",
-        deposit_memo: null,
+        deposit_memo: undefined,
       };
 
       // add a new success message
@@ -688,7 +683,7 @@ describe("Anchor", () => {
         id: "def5d166-5a5e-4d5c-ba5d-271c32cd8abc",
         kind: "withdrawal",
         status: TransactionStatus.refunded,
-        status_eta: null,
+        status_eta: undefined,
         amount_in: "95.35",
         amount_in_asset:
           "stellar:SRT:GCDNJUBQSX7AJWLJACMJ7I4BC3Z47BQUTMHEICZLE6MU4KQBRYG5JY6B",
@@ -701,7 +696,7 @@ describe("Anchor", () => {
         completed_at: "2023-05-26T15:12:35.128156Z",
         stellar_transaction_id:
           "abu0b2292c4e09e8eb22d036171491e87b8d2086bf8b265874c8d182cb9cdega",
-        external_transaction_id: null,
+        external_transaction_id: undefined,
         more_info_url:
           "https://testanchor.stellar.org/sep24/transaction/more_info?id=def5d166-5a5e-4d5c-ba5d-271c32cd8abc",
         refunds: {
@@ -722,8 +717,8 @@ describe("Anchor", () => {
             },
           ],
         },
-        message: null,
-        to: null,
+        message: undefined,
+        to: undefined,
         from: "GCZSYKPDWAKPGR7GYFBOIQB3TH352X7ELZL27WSJET5PDVFORDMGYTB5",
         withdraw_memo_type: "hash",
         withdraw_memo: "AAAAAAAAAAAAAAAAAAAAANsV0WZaXk1cul0nHDLNjPA=",
@@ -759,22 +754,22 @@ describe("Anchor", () => {
         id: "hytcf7c4-927d-4b7a-8a1f-d7188ebddu8i",
         kind: "withdrawal",
         status: TransactionStatus.expired,
-        status_eta: null,
-        amount_in: null,
-        amount_out: null,
-        amount_fee: null,
+        status_eta: undefined,
+        amount_in: undefined,
+        amount_out: undefined,
+        amount_fee: undefined,
         started_at: "2023-05-25T18:56:29.615274Z",
-        completed_at: null,
-        stellar_transaction_id: null,
-        external_transaction_id: null,
+        completed_at: undefined,
+        stellar_transaction_id: undefined,
+        external_transaction_id: undefined,
         more_info_url:
           "https://testanchor.stellar.org/sep24/transaction/more_info?id=hytcf7c4-927d-4b7a-8a1f-d7188ebddu8i",
         message: "transaction has expired",
-        to: null,
+        to: undefined,
         from: "GCZSYKPDWAKPGR7GYFBOIQB3TH352X7ELZL27WSJET5PDVFORDMGYTB5",
         withdraw_memo_type: "hash",
-        withdraw_memo: null,
-        withdraw_anchor_account: null,
+        withdraw_memo: undefined,
+        withdraw_anchor_account: undefined,
       };
 
       // add a new success message
@@ -1694,7 +1689,7 @@ describe("Http client", () => {
     const accountKp = Keypair.fromSecret(
       "SDXC3OHSJZEQIXKEWFDNEZEQ7SW5DWBPW7RKUWI36ILY3QZZ6VER7TXV",
     );
-    const client = walletSdk.DefaultClient;
+    const client = DefaultClient;
 
     const resp = await client.get(
       `http://testanchor.stellar.org/auth?account=${accountKp.publicKey()}`,


### PR DESCRIPTION
Related:
- https://stellarorg.atlassian.net/browse/WAL-767
- https://stellarorg.atlassian.net/browse/WAL-771

Since the [Kotlin SDK is removing the formatting functions/classes](https://stellarfoundation.slack.com/archives/C03347FNAHK/p1690812866775379) let's just return the "raw" ServerApi responses for now.

This PR also cleans up some code from test files.
