### PR TITLE
Export new classes to wallets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,14 +14,16 @@ export {
   ApplicationConfiguration,
 } from "./walletSdk";
 export { Anchor } from "./walletSdk/Anchor";
+export { Sep24 } from "./walletSdk/Anchor/Sep24";
+export { IssuedAssetId, NativeAssetId, FiatAssetId } from "./walletSdk/Asset";
 export { Sep10, WalletSigner, DefaultSigner } from "./walletSdk/Auth";
 export {
   PublicKeypair,
   SigningKeypair,
   AccountService,
   Stellar,
+  TransactionBuilder
 } from "./walletSdk/Horizon";
-export { Sep24 } from "./walletSdk/Anchor/Sep24";
 export { Recovery } from "./walletSdk/Recovery";
 export { Watcher } from "./walletSdk/Watcher";
 

--- a/src/walletSdk/Horizon/Stellar.ts
+++ b/src/walletSdk/Horizon/Stellar.ts
@@ -8,7 +8,7 @@ import {
 
 import { Config } from "walletSdk";
 import { AccountService } from "./AccountService";
-import { TransactionBuilder } from "./transaction/TransactionBuilder";
+import { TransactionBuilder } from "./Transaction/TransactionBuilder";
 import { TransactionParams, SubmitWithFeeIncreaseParams } from "../Types";
 import {
   AccountDoesNotExistError,

--- a/src/walletSdk/Horizon/index.ts
+++ b/src/walletSdk/Horizon/index.ts
@@ -1,3 +1,4 @@
 export { PublicKeypair, SigningKeypair } from "./Account";
 export { AccountService } from "./AccountService";
 export { Stellar } from "./Stellar";
+export { TransactionBuilder } from "./Transaction/TransactionBuilder";


### PR DESCRIPTION
Exports `IssuedAssetId, NativeAssetId, FiatAssetId and TransactionBuilder` classes.

Every time a new class is created we should add it to `src/index`'s export list so we make sure wallets(clients) will be able to access it.