### PR TITLE
check if withdraw memo is hash type

### DIFF
--- a/src/walletSdk/Exceptions/index.ts
+++ b/src/walletSdk/Exceptions/index.ts
@@ -146,3 +146,10 @@ export class WithdrawalTxMissingMemoError extends Error {
     Object.setPrototypeOf(this, WithdrawalTxMissingMemoError.prototype);
   }
 }
+
+export class WithdrawalTxMemoError extends Error {
+  constructor() {
+    super(`Error parsing withdrawal transaction memo`);
+    Object.setPrototypeOf(this, WithdrawalTxMemoError.prototype);
+  }
+}

--- a/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
+++ b/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
@@ -132,8 +132,9 @@ export class TransactionBuilder {
 
     if (transaction.withdraw_memo_type === "hash") {
       try {
-        const parsed = xdr["Memo"].fromXDR(transaction.withdraw_memo, "base64");
-        this.setMemo(Memo.fromXDRObject(parsed));
+        const buffer = Buffer.from(transaction.withdraw_memo, "base64");
+        const memo = Memo.hash(buffer.toString("hex"));
+        this.setMemo(memo);
       } catch {
         throw new WithdrawalTxMemoError();
       }

--- a/test/stellar.test.ts
+++ b/test/stellar.test.ts
@@ -198,32 +198,49 @@ describe("Stellar", () => {
     kp.sign(tx);
   });
   it("should transfer withdrawal transaction", async () => {
-    const walletTransaction = {
-      id: "db15d166-5a5e-4d5c-ba5d-271c32cd8cf0",
-      kind: "withdrawal",
-      status: TransactionStatus.pending_user_transfer_start,
-      amount_in: "50.55",
-      withdraw_memo_type: "text",
-      withdraw_memo: "the withdraw memo",
-      withdraw_anchor_account:
-        "GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE",
-    } as WithdrawTransaction;
+    const memoExamples = [
+      {
+        type: "text",
+        value: "example text",
+      },
+      {
+        type: "id",
+        value: "12345",
+      },
+      {
+        type: "hash",
+        value: "AAAAAAAAAAAAAAAAAAAAAMAP+8deo0TViBD09TfOBY0=",
+      },
+    ];
 
-    const asset = new IssuedAssetId(
-      "USDC",
-      "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
-    );
+    for (const memoExample of memoExamples) {
+      const walletTransaction = {
+        id: "db15d166-5a5e-4d5c-ba5d-271c32cd8cf0",
+        kind: "withdrawal",
+        status: TransactionStatus.pending_user_transfer_start,
+        amount_in: "50.55",
+        withdraw_memo_type: memoExample.type,
+        withdraw_memo: memoExample.value,
+        withdraw_anchor_account:
+          "GCSGSR6KQQ5BP2FXVPWRL6SWPUSFWLVONLIBJZUKTVQB5FYJFVL6XOXE",
+      } as WithdrawTransaction;
 
-    const txBuilder = await stellar.transaction({
-      sourceAddress: kp,
-      baseFee: 100,
-    });
+      const asset = new IssuedAssetId(
+        "USDC",
+        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+      );
 
-    const txn = txBuilder
-      .transferWithdrawalTransaction(walletTransaction, asset)
-      .build();
-    expect(txn).toBeTruthy();
-  });
+      const txBuilder = await stellar.transaction({
+        sourceAddress: kp,
+        baseFee: 100,
+      });
+
+      const txn = txBuilder
+        .transferWithdrawalTransaction(walletTransaction, asset)
+        .build();
+      expect(txn).toBeTruthy();
+    }
+  }, 20000);
 });
 
 describe("Asset", () => {

--- a/test/stellar.test.ts
+++ b/test/stellar.test.ts
@@ -36,7 +36,7 @@ describe("Stellar", () => {
     } catch (e) {
       await axios.get("https://friendbot.stellar.org/?addr=" + kp.publicKey);
     }
-  });
+  }, 10000);
   it("should create and submit a transaction", async () => {
     const now = Math.floor(Date.now() / 1000) - 5;
 
@@ -210,6 +210,10 @@ describe("Stellar", () => {
       {
         type: "hash",
         value: "AAAAAAAAAAAAAAAAAAAAAMAP+8deo0TViBD09TfOBY0=",
+      },
+      {
+        type: "hash",
+        value: "MV9b23bQeMQ7isAGTkoBZGErH853yGk0W/yUx1iU7dM=",
       },
     ];
 


### PR DESCRIPTION
found a bug for when memo is hash type and sending a withdrawal transaction, it needs to handle the memo value


merging into release/1.1.3, thinking it can go out with the stellar-sdk version upgrade going out this week