### PR TITLE
better axios error handling (pt 2)

### DIFF
--- a/src/walletSdk/Exceptions/index.ts
+++ b/src/walletSdk/Exceptions/index.ts
@@ -1,12 +1,15 @@
 import { Networks, Horizon } from "stellar-sdk";
 import axios from "axios";
-import { AnchorTransaction, FLOW_TYPE } from "../Types";
+import { AnchorTransaction, FLOW_TYPE, AxiosErrorData } from "../Types";
 import { extractAxiosErrorData } from "../Utils";
 
 export class ServerRequestFailedError extends Error {
+  data: AxiosErrorData;
+
   constructor(e: Error) {
     if (axios.isAxiosError(e)) {
-      super(`Server request failed with error: ${extractAxiosErrorData(e)}`);
+      super(`Server request failed with error`);
+      this.data = extractAxiosErrorData(e);
     } else {
       super(`Server request failed with error: ${e}`);
     }

--- a/src/walletSdk/Exceptions/index.ts
+++ b/src/walletSdk/Exceptions/index.ts
@@ -8,8 +8,13 @@ export class ServerRequestFailedError extends Error {
 
   constructor(e: Error) {
     if (axios.isAxiosError(e)) {
-      super(`Server request failed with error`);
-      this.data = extractAxiosErrorData(e);
+      const errorData = extractAxiosErrorData(e);
+      const message =
+        errorData.responseData && Object.keys(errorData.responseData).length > 0
+          ? JSON.stringify(errorData.responseData)
+          : errorData.statusText;
+      super(`Server request failed with error: ${errorData.status} ${message}`);
+      this.data = errorData;
     } else {
       super(`Server request failed with error: ${e}`);
     }

--- a/src/walletSdk/Types/index.ts
+++ b/src/walletSdk/Types/index.ts
@@ -1,4 +1,4 @@
-import { AxiosRequestConfig } from "axios";
+import { RawAxiosRequestHeaders } from "axios";
 import { Server, Networks } from "stellar-sdk";
 import { ApplicationConfiguration, StellarConfiguration } from "walletSdk";
 
@@ -28,6 +28,13 @@ export type StellarConfigurationParams = {
   horizonUrl: string;
   baseFee?: number;
   defaultTimeout?: number;
+};
+
+export type AxiosErrorData = {
+  status?: number;
+  statusText?: string;
+  responseData?: any;
+  headers?: RawAxiosRequestHeaders;
 };
 
 // Export all other types from walletSdk/Types.ts

--- a/src/walletSdk/Utils/extractAxiosErrorData.ts
+++ b/src/walletSdk/Utils/extractAxiosErrorData.ts
@@ -1,28 +1,28 @@
 import axios from "axios";
+import { AxiosErrorData } from "../Types";
 
 // Based on https://axios-http.com/docs/handling_errors
-export const extractAxiosErrorData = (error: Error): string => {
-  if (!axios.isAxiosError(error)) {
-    return JSON.stringify(error);
-  }
 
+export const extractAxiosErrorData = (error: Error): AxiosErrorData => {
+  if (!axios.isAxiosError(error)) {
+    return { responseData: JSON.stringify(error) };
+  }
   if (error.response) {
-    // The request was made and the server responded with a status code
-    // that falls out of the range of 2xx
-    return (
-      `Server request failed with error:\n` +
-      `Status: ${error.response.status}\n` +
-      `Status Text: ${error.response.statusText}\n` +
-      `Response Data: ${JSON.stringify(error.response.data)}\n` +
-      `Headers: ${JSON.stringify(error.response.headers)}`
-    );
+    return {
+      status: error.response.status,
+      statusText: error.response.statusText,
+      responseData: error.response.data,
+      headers: error.response.headers,
+    };
   } else if (error.request) {
     // The request was made but no response was received
-    return `No response received from request: ${JSON.stringify(
-      error.request,
-    )}`;
+    return {
+      statusText: `No response received from request: ${JSON.stringify(
+        error.request,
+      )}`,
+    };
   } else {
     // Something happened in setting up the request that triggered an Error
-    return `Failed request with error: ${error.message}`;
+    return { statusText: `Failed request with error: ${error.message}` };
   }
 };

--- a/test/wallet.test.ts
+++ b/test/wallet.test.ts
@@ -195,6 +195,25 @@ describe("Anchor", () => {
     expect(resp.id).toBeTruthy();
   });
 
+  it("should throw ServerRequestFailedError", async () => {
+    const assetCode = "SRT";
+    let didError = false;
+    try {
+      const resp = await anchor.sep24().withdraw({
+        withdrawalAccount: accountKp.publicKey,
+        assetCode,
+        authToken: "bad auth token",
+      });
+    } catch (e) {
+      didError = true;
+      expect(e.data.status).toBe(403);
+      expect(e.data.statusText).toBe("Forbidden");
+      expect(e.data.responseData.error).toBeTruthy();
+      expect(e.data.headers).toBeTruthy();
+    }
+    expect(didError).toBe(true);
+  });
+
   it("should fetch new transaction by id", async () => {
     const assetCode = "SRT";
 


### PR DESCRIPTION
in making the changes from the PR comments here: https://github.com/stellar/typescript-wallet-sdk/pull/67

I decided to return the error with `AxiosErrorData` in the data field instead of one large string, which will make using the error object much easier if needed

the error in total will look like this if a http request fails:
<img width="597" alt="Screen Shot 2023-10-03 at 9 26 00 PM" src="https://github.com/stellar/typescript-wallet-sdk/assets/30449853/7da81c8e-d3a4-4923-adf9-8b48b6de5f89">

