### PR TITLE
[Soroban] Add token parsing/formatting functions

### DIFF
--- a/src/walletSdk/Utils/soroban.ts
+++ b/src/walletSdk/Utils/soroban.ts
@@ -1,4 +1,5 @@
 import { Operation, StrKey, scValToNative, xdr } from "@stellar/stellar-sdk";
+import BigNumber from "bignumber.js";
 
 import {
   ArgsForTokenInvocation,
@@ -81,4 +82,32 @@ export const getTokenInvocationArgs = (
     contractId,
     ...opArgs,
   };
+};
+
+// Adopted from https://github.com/ethers-io/ethers.js/blob/master/packages/bignumber/src.ts/fixednumber.ts#L27
+export const formatTokenAmount = (
+  amount: BigNumber | bigint | number | string,
+  decimals: number,
+): string => {
+  const bigNumberAmount = new BigNumber(amount.toString());
+
+  let formatted = bigNumberAmount.toString();
+
+  if (decimals > 0) {
+    formatted = bigNumberAmount
+      .shiftedBy(-decimals)
+      .toFixed(decimals)
+      .toString();
+
+    // Trim trailing zeros
+    while (formatted[formatted.length - 1] === "0") {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+
+    if (formatted.endsWith(".")) {
+      formatted = formatted.substring(0, formatted.length - 1);
+    }
+  }
+
+  return formatted;
 };

--- a/src/walletSdk/Utils/soroban.ts
+++ b/src/walletSdk/Utils/soroban.ts
@@ -159,6 +159,8 @@ export const parseTokenAmount = (
   const wholeValue = new BigNumber(whole);
   const fractionValue = new BigNumber(fraction);
 
+  // This basically appends the 'whole' and 'fraction' values into
+  // an integer value
   const parsed = wholeValue.shiftedBy(decimals).plus(fractionValue);
 
   return BigInt(parsed.toString());

--- a/test/soroban.test.ts
+++ b/test/soroban.test.ts
@@ -11,6 +11,7 @@ import BigNumber from "bignumber.js";
 import {
   formatTokenAmount,
   getTokenInvocationArgs,
+  parseTokenAmount,
 } from "../src/walletSdk/Utils";
 import { SorobanTokenInterface } from "../src/walletSdk/Types";
 
@@ -81,19 +82,38 @@ describe("Soroban Utils", () => {
   it("should format different types of token amount values", () => {
     const formatted = "1000000.1234567";
 
-    const value2 = BigInt("10000001234567");
-    expect(formatTokenAmount(value2, 7)).toBe(formatted);
+    const value1 = BigInt(10000001234567);
+    expect(formatTokenAmount(value1, 7)).toStrictEqual(formatted);
 
-    const value1 = new BigNumber("10000001234567");
-    expect(formatTokenAmount(value1, 7)).toBe(formatted);
+    const value2 = new BigNumber("10000001234567");
+    expect(formatTokenAmount(value2, 7)).toStrictEqual(formatted);
 
     const value3 = Number("10000001234567");
-    expect(formatTokenAmount(value3, 7)).toBe(formatted);
+    expect(formatTokenAmount(value3, 7)).toStrictEqual(formatted);
 
     const value4 = 10000001234567;
-    expect(formatTokenAmount(value4, 7)).toBe(formatted);
+    expect(formatTokenAmount(value4, 7)).toStrictEqual(formatted);
 
     const value5 = "10000001234567";
-    expect(formatTokenAmount(value5, 7)).toBe(formatted);
+    expect(formatTokenAmount(value5, 7)).toStrictEqual(formatted);
+  });
+
+  it("should parse different types of token amount values", () => {
+    const parsed = BigInt(10000001234567);
+
+    const value5 = "1000000.1234567";
+    expect(parseTokenAmount(value5, 7) === parsed).toBeTruthy();
+
+    const value4 = 1000000.1234567;
+    expect(parseTokenAmount(value4, 7) === parsed).toBeTruthy();
+
+    const value3 = Number("1000000.1234567");
+    expect(parseTokenAmount(value3, 7) === parsed).toBeTruthy();
+
+    const value2 = new BigNumber("1000000.1234567");
+    expect(parseTokenAmount(value2, 7) === parsed).toBeTruthy();
+
+    const value1 = BigInt("123");
+    expect(parseTokenAmount(value1, 3) === BigInt(123000)).toBeTruthy();
   });
 });

--- a/test/soroban.test.ts
+++ b/test/soroban.test.ts
@@ -6,8 +6,12 @@ import {
   Transaction,
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
+import BigNumber from "bignumber.js";
 
-import { getTokenInvocationArgs } from "../src/walletSdk/Utils";
+import {
+  formatTokenAmount,
+  getTokenInvocationArgs,
+} from "../src/walletSdk/Utils";
 import { SorobanTokenInterface } from "../src/walletSdk/Types";
 
 const transactions = {
@@ -72,5 +76,24 @@ describe("Soroban Utils", () => {
     const args = getTokenInvocationArgs(op);
 
     expect(args).toBe(null);
+  });
+
+  it("should format different types of token amount values", () => {
+    const formatted = "1000000.1234567";
+
+    const value2 = BigInt("10000001234567");
+    expect(formatTokenAmount(value2, 7)).toBe(formatted);
+
+    const value1 = new BigNumber("10000001234567");
+    expect(formatTokenAmount(value1, 7)).toBe(formatted);
+
+    const value3 = Number("10000001234567");
+    expect(formatTokenAmount(value3, 7)).toBe(formatted);
+
+    const value4 = 10000001234567;
+    expect(formatTokenAmount(value4, 7)).toBe(formatted);
+
+    const value5 = "10000001234567";
+    expect(formatTokenAmount(value5, 7)).toBe(formatted);
   });
 });


### PR DESCRIPTION
https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?selectedIssue=WAL-1367

Differences when compared to [Freighter's implementation](https://github.com/stellar/freighter/blob/master/extension/src/popup/helpers/soroban.ts#L57):
- Both functions take all 4 input types: `bigint | BigNumber | number | string`;
- `parseTokenAmount` function returns `bigint` instead of `BigNumber` since `bigint` seems to be the default numbering format used in the soroban env;