### PR TITLE
fix stellar-sdk imports

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
@@ -1,5 +1,8 @@
 import { AxiosInstance } from "axios";
-import StellarSdk, { Transaction } from "@stellar/stellar-sdk";
+import {
+  TransactionBuilder as StellarTransactionBuilder,
+  Transaction,
+} from "@stellar/stellar-sdk";
 import { decode } from "jws";
 
 import { Config } from "walletSdk";
@@ -118,7 +121,7 @@ export class Sep10 {
     challengeResponse,
     walletSigner,
   }: SignParams): Promise<Transaction> {
-    let transaction: Transaction = StellarSdk.TransactionBuilder.fromXDR(
+    let transaction: Transaction = StellarTransactionBuilder.fromXDR(
       challengeResponse.transaction,
       challengeResponse.network_passphrase,
     );

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
@@ -1,8 +1,5 @@
 import { AxiosInstance } from "axios";
-import {
-  TransactionBuilder as StellarTransactionBuilder,
-  Transaction,
-} from "@stellar/stellar-sdk";
+import { TransactionBuilder, Transaction } from "@stellar/stellar-sdk";
 import { decode } from "jws";
 
 import { Config } from "walletSdk";
@@ -121,10 +118,10 @@ export class Sep10 {
     challengeResponse,
     walletSigner,
   }: SignParams): Promise<Transaction> {
-    let transaction: Transaction = StellarTransactionBuilder.fromXDR(
+    let transaction: Transaction = TransactionBuilder.fromXDR(
       challengeResponse.transaction,
       challengeResponse.network_passphrase,
-    );
+    ) as Transaction;
 
     // check if verifying client domain as well
     for (const op of transaction.operations) {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/CommonTransactionBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/CommonTransactionBuilder.ts
@@ -1,4 +1,4 @@
-import StellarSdk, { xdr } from "@stellar/stellar-sdk";
+import { Operation, xdr } from "@stellar/stellar-sdk";
 import { IssuedAssetId } from "../../Asset";
 import { AccountKeypair } from "../Account";
 
@@ -19,7 +19,7 @@ export abstract class CommonTransactionBuilder<T> {
    */
   addAssetSupport(asset: IssuedAssetId, trustLimit?: string): T {
     this.operations.push(
-      StellarSdk.Operation.changeTrust({
+      Operation.changeTrust({
         asset: asset.toAsset(),
         limit: trustLimit,
         source: this.sourceAddress,
@@ -46,7 +46,7 @@ export abstract class CommonTransactionBuilder<T> {
    */
   addAccountSigner(signerAddress: AccountKeypair, signerWeight: number): T {
     this.operations.push(
-      StellarSdk.Operation.setOptions({
+      Operation.setOptions({
         source: this.sourceAddress,
         signer: {
           ed25519PublicKey: signerAddress.publicKey,
@@ -75,7 +75,7 @@ export abstract class CommonTransactionBuilder<T> {
    */
   lockAccountMasterKey(): T {
     this.operations.push(
-      StellarSdk.Operation.setOptions({
+      Operation.setOptions({
         source: this.sourceAddress,
         masterWeight: 0,
       }),
@@ -102,7 +102,7 @@ export abstract class CommonTransactionBuilder<T> {
     high?: number;
   }): T {
     this.operations.push(
-      StellarSdk.Operation.setOptions({
+      Operation.setOptions({
         source: this.sourceAddress,
         lowThreshold: low,
         medThreshold: medium,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/SponsoringBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/SponsoringBuilder.ts
@@ -1,4 +1,4 @@
-import StellarSdk, { xdr } from "@stellar/stellar-sdk";
+import { Operation, xdr } from "@stellar/stellar-sdk";
 
 import { CommonTransactionBuilder } from "./CommonTransactionBuilder";
 import { AccountKeypair } from "../Account";
@@ -45,7 +45,7 @@ export class SponsoringBuilder extends CommonTransactionBuilder<SponsoringBuilde
     startingBalance: number = 0,
   ): SponsoringBuilder {
     this.operations.push(
-      StellarSdk.Operation.createAccount({
+      Operation.createAccount({
         destination: newAccount.publicKey,
         startingBalance: startingBalance.toString(),
         source: this.sponsorAccount.publicKey,
@@ -60,7 +60,7 @@ export class SponsoringBuilder extends CommonTransactionBuilder<SponsoringBuilde
    */
   startSponsoring() {
     this.operations.push(
-      StellarSdk.Operation.beginSponsoringFutureReserves({
+      Operation.beginSponsoringFutureReserves({
         sponsoredId: this.sourceAddress,
         source: this.sponsorAccount.publicKey,
       }),
@@ -73,7 +73,7 @@ export class SponsoringBuilder extends CommonTransactionBuilder<SponsoringBuilde
    */
   stopSponsoring() {
     this.operations.push(
-      StellarSdk.Operation.endSponsoringFutureReserves({
+      Operation.endSponsoringFutureReserves({
         source: this.sourceAddress,
       }),
     );

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
@@ -1,4 +1,5 @@
-import StellarSdk, {
+import {
+  Operation,
   TransactionBuilder as StellarTransactionBuilder,
   Account as StellarAccount,
   Transaction,
@@ -101,7 +102,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
     }
 
     this.operations.push(
-      StellarSdk.Operation.createAccount({
+      Operation.createAccount({
         destination: newAccount.publicKey,
         startingBalance: startingBalance.toString(),
         source: this.sourceAddress,
@@ -123,7 +124,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
     amount: string,
   ): TransactionBuilder {
     this.operations.push(
-      StellarSdk.Operation.payment({
+      Operation.payment({
         destination: destinationAddress,
         asset: assetId.toAsset(),
         amount,
@@ -167,7 +168,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
     }
     if (sendAmount) {
       this.operations.push(
-        StellarSdk.Operation.pathPaymentStrictSend({
+        Operation.pathPaymentStrictSend({
           destination: destinationAddress,
           sendAsset: sendAsset.toAsset(),
           sendAmount,
@@ -177,7 +178,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
       );
     } else {
       this.operations.push(
-        StellarSdk.Operation.pathPaymentStrictReceive({
+        Operation.pathPaymentStrictReceive({
           destination: destinationAddress,
           sendAsset: sendAsset.toAsset(),
           destAmount,
@@ -289,9 +290,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
    * @returns {TransactionBuilder} The TransactionBuilder instance.
    */
   accountMerge(destination: string, source?: string): TransactionBuilder {
-    this.operations.push(
-      StellarSdk.Operation.accountMerge({ destination, source }),
-    );
+    this.operations.push(Operation.accountMerge({ destination, source }));
     return this;
   }
 


### PR DESCRIPTION
user noticed when importing the full SDK it returns undefined in React-Native and React environment. 
closes https://github.com/stellar/typescript-wallet-sdk/issues/103

Seems to be the way the stellar-sdk is built? Left a [ticket](https://github.com/stellar/js-stellar-sdk/issues/931) asking there

Changing all the imports to be the destructured way now, makes it more consistent anyways