### PR TITLE
webpack fix

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk-km/webpack.config.js
@@ -1,43 +1,51 @@
 const path = require("path");
 const webpack = require("webpack");
 
-module.exports = (env = { NODE: false }) => ({
-  mode: "development",
-  entry: "./src/index.ts",
-  devtool: "source-map",
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: "ts-loader",
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    extensions: [".js", ".json", ".ts"],
-    fallback: {
-      crypto: require.resolve("crypto-browserify"),
-      http: require.resolve("stream-http"),
-      https: require.resolve("https-browserify"),
-      stream: require.resolve("stream-browserify"),
-      url: require.resolve("url"),
-      util: require.resolve("util"),
-      vm: require.resolve("vm-browserify"),
-      "process/browser": require.resolve("process/browser"),
+module.exports = (env = { NODE: false }) => {
+  const isBrowser = !env.NODE;
+
+  return {
+    mode: "development",
+    entry: "./src/index.ts",
+    devtool: "source-map",
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: "ts-loader",
+          exclude: /node_modules/,
+        },
+      ],
     },
-  },
-  output: {
-    library: "WalletSdkKm",
-    libraryTarget: "umd",
-    globalObject: "this",
-    filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
-    path: path.resolve(__dirname, "lib"),
-  },
-  target: env.NODE ? "node" : "web",
-  plugins: [
-    new webpack.ProvidePlugin({
-      process: "process/browser",
-    }),
-  ],
-});
+    resolve: {
+      extensions: [".js", ".json", ".ts"],
+      fallback: isBrowser
+        ? {
+            crypto: require.resolve("crypto-browserify"),
+            http: require.resolve("stream-http"),
+            https: require.resolve("https-browserify"),
+            stream: require.resolve("stream-browserify"),
+            url: require.resolve("url"),
+            util: require.resolve("util"),
+            vm: require.resolve("vm-browserify"),
+            "process/browser": require.resolve("process/browser"),
+          }
+        : {},
+    },
+    output: {
+      library: "WalletSDK",
+      libraryTarget: "umd",
+      globalObject: "this",
+      filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
+      path: path.resolve(__dirname, "lib"),
+    },
+    target: env.NODE ? "node" : "web",
+    plugins: isBrowser
+      ? [
+          new webpack.ProvidePlugin({
+            process: "process/browser",
+          }),
+        ]
+      : [],
+  };
+};

--- a/@stellar/typescript-wallet-sdk-km/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk-km/webpack.config.js
@@ -36,10 +36,10 @@ module.exports = (env = { NODE: false }) => {
       library: "WalletSDK",
       libraryTarget: "umd",
       globalObject: "this",
-      filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
+      filename: `bundle${isBrowser ? "_browser" : ""}.js`,
       path: path.resolve(__dirname, "lib"),
     },
-    target: env.NODE ? "node" : "web",
+    target: isBrowser ? "web" : "node",
     plugins: isBrowser
       ? [
           new webpack.ProvidePlugin({

--- a/@stellar/typescript-wallet-sdk/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk/webpack.config.js
@@ -1,43 +1,51 @@
 const path = require("path");
 const webpack = require("webpack");
 
-module.exports = (env = { NODE: false }) => ({
-  mode: "development",
-  entry: "./src/index.ts",
-  devtool: "source-map",
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: "ts-loader",
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    extensions: [".js", ".json", ".ts"],
-    fallback: {
-      crypto: require.resolve("crypto-browserify"),
-      http: require.resolve("stream-http"),
-      https: require.resolve("https-browserify"),
-      stream: require.resolve("stream-browserify"),
-      url: require.resolve("url"),
-      util: require.resolve("util"),
-      vm: require.resolve("vm-browserify"),
-      "process/browser": require.resolve("process/browser"),
+module.exports = (env = { NODE: false }) => {
+  const isBrowser = !env.NODE;
+
+  return {
+    mode: "development",
+    entry: "./src/index.ts",
+    devtool: "source-map",
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: "ts-loader",
+          exclude: /node_modules/,
+        },
+      ],
     },
-  },
-  output: {
-    library: "WalletSDK",
-    libraryTarget: "umd",
-    globalObject: "this",
-    filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
-    path: path.resolve(__dirname, "lib"),
-  },
-  target: env.NODE ? "node" : "web",
-  plugins: [
-    new webpack.ProvidePlugin({
-      process: "process/browser",
-    }),
-  ],
-});
+    resolve: {
+      extensions: [".js", ".json", ".ts"],
+      fallback: isBrowser
+        ? {
+            crypto: require.resolve("crypto-browserify"),
+            http: require.resolve("stream-http"),
+            https: require.resolve("https-browserify"),
+            stream: require.resolve("stream-browserify"),
+            url: require.resolve("url"),
+            util: require.resolve("util"),
+            vm: require.resolve("vm-browserify"),
+            "process/browser": require.resolve("process/browser"),
+          }
+        : {},
+    },
+    output: {
+      library: "WalletSDK",
+      libraryTarget: "umd",
+      globalObject: "this",
+      filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
+      path: path.resolve(__dirname, "lib"),
+    },
+    target: env.NODE ? "node" : "web",
+    plugins: isBrowser
+      ? [
+          new webpack.ProvidePlugin({
+            process: "process/browser",
+          }),
+        ]
+      : [],
+  };
+};

--- a/@stellar/typescript-wallet-sdk/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk/webpack.config.js
@@ -36,10 +36,10 @@ module.exports = (env = { NODE: false }) => {
       library: "WalletSDK",
       libraryTarget: "umd",
       globalObject: "this",
-      filename: `bundle${!env.NODE ? "_browser" : ""}.js`,
+      filename: `bundle${isBrowser ? "_browser" : ""}.js`,
       path: path.resolve(__dirname, "lib"),
     },
-    target: env.NODE ? "node" : "web",
+    target: isBrowser ? "web" : "node",
     plugins: isBrowser
       ? [
           new webpack.ProvidePlugin({


### PR DESCRIPTION
when testing release/1.4.0 I realized one of the changes I made for the webpack build for react was causing an error for the nodeJS build, so this change further separates the environments

I added a [ticket](https://stellarorg.atlassian.net/browse/WAL-1404) to automate testing the different build environments, right now we're just auto testing nodeJS