### PR TITLE
[Soroban] Add getTokenInvocationArgs function in new workspace

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,8 @@ module.exports = {
       "@stellar/typescript-wallet-sdk/test/tsconfig.json",
       "@stellar/typescript-wallet-sdk-km/tsconfig.json",
       "@stellar/typescript-wallet-sdk-km/test/tsconfig.json",
+      "@stellar/typescript-wallet-sdk-soroban/tsconfig.json",
+      "@stellar/typescript-wallet-sdk-soroban/test/tsconfig.json",
     ],
     sourceType: "module",
   },

--- a/@stellar/typescript-wallet-sdk-soroban/babel.config.js
+++ b/@stellar/typescript-wallet-sdk-soroban/babel.config.js
@@ -1,0 +1,5 @@
+const parentConfig = require("../../babel.config");
+
+module.exports = {
+  ...parentConfig,
+};

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@stellar/typescript-wallet-sdk-soroban",
+  "version": "1.0.0",
+  "engines": {
+    "node": ">=18"
+  },
+  "browser": "./lib/bundle_browser.js",
+  "main": "./lib/bundle.js",
+  "types": "./lib/index.d.ts",
+  "license": "Apache-2.0",
+  "private": false,
+  "devDependencies": {
+    "@babel/preset-env": "^7.24.0",
+    "@babel/preset-typescript": "^7.23.3",
+    "@stellar/prettier-config": "^1.0.1",
+    "@stellar/tsconfig": "^1.0.2",
+    "@types/jest": "^29.5.12",
+    "@typescript-eslint/parser": "^7.1.1",
+    "babel-jest": "^29.7.0",
+    "husky": "^9.0.11",
+    "jest": "^29.7.0",
+    "npm-run-all": "^4.1.5",
+    "ts-jest": "^29.1.2",
+    "ts-loader": "^9.5.1",
+    "tslib": "^2.6.2",
+    "typescript": "^5.3.3",
+    "webpack": "^5.90.3",
+    "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^11.1.0"
+  },
+  "scripts": {
+    "prepare": "husky install",
+    "test": "jest --watchAll",
+    "test:ci": "jest --ci",
+    "build:web": "webpack --config webpack.config.js",
+    "build:node": "webpack --env NODE=true --config webpack.config.js",
+    "build": "run-p build:web build:node"
+  }
+}

--- a/@stellar/typescript-wallet-sdk-soroban/src/Helpers/index.ts
+++ b/@stellar/typescript-wallet-sdk-soroban/src/Helpers/index.ts
@@ -1,0 +1,1 @@
+export * from "./tokenInvocation";

--- a/@stellar/typescript-wallet-sdk-soroban/src/Helpers/tokenInvocation.ts
+++ b/@stellar/typescript-wallet-sdk-soroban/src/Helpers/tokenInvocation.ts
@@ -1,0 +1,94 @@
+import { Operation, StrKey, scValToNative, xdr } from "@stellar/stellar-sdk";
+
+import {
+  ArgsForTokenInvocation,
+  SorobanTokenInterface,
+  TokenInvocationArgs,
+} from "../Types";
+
+export const getArgsForTokenInvocation = (
+  fnName: string,
+  args: xdr.ScVal[],
+): ArgsForTokenInvocation => {
+  let amount: bigint | number;
+  let from = "";
+  let to = "";
+
+  switch (fnName) {
+    case SorobanTokenInterface.transfer:
+      from = StrKey.encodeEd25519PublicKey(
+        args[0].address().accountId().ed25519(),
+      );
+      to = StrKey.encodeEd25519PublicKey(
+        args[1].address().accountId().ed25519(),
+      );
+      amount = scValToNative(args[2]);
+      break;
+    case SorobanTokenInterface.mint:
+      to = StrKey.encodeEd25519PublicKey(
+        args[0].address().accountId().ed25519(),
+      );
+      amount = scValToNative(args[1]);
+      break;
+    default:
+      amount = BigInt(0);
+  }
+
+  return { from, to, amount };
+};
+
+/**
+ * Get params and args related to the invoked contract. It must use a valid
+ * "transfer" or "mint" invocation otherwise it will return 'null'.
+ *
+ * @param {Operation.InvokeHostFunction} hostFn - The invoke host function.
+ *
+ * @returns {TokenInvocationArgs | null} Params and args related to the
+ * "transfer" or "mint" invocation like function name, contract id, from/to
+ * addresses and amount.
+ */
+export const getTokenInvocationArgs = (
+  hostFn: Operation.InvokeHostFunction,
+): TokenInvocationArgs | null => {
+  if (!hostFn?.func?.invokeContract) {
+    return null;
+  }
+
+  let invokedContract: xdr.InvokeContractArgs;
+
+  try {
+    invokedContract = hostFn.func.invokeContract();
+  } catch (e) {
+    return null;
+  }
+
+  const contractId = StrKey.encodeContract(
+    invokedContract.contractAddress().contractId(),
+  );
+  const fnName = invokedContract
+    .functionName()
+    .toString() as SorobanTokenInterface;
+  const args = invokedContract.args();
+
+  if (
+    ![SorobanTokenInterface.transfer, SorobanTokenInterface.mint].includes(
+      fnName,
+    )
+  ) {
+    return null;
+  }
+
+  let opArgs: ArgsForTokenInvocation;
+
+  try {
+    opArgs = getArgsForTokenInvocation(fnName, args);
+  } catch (e) {
+    return null;
+  }
+
+  return {
+    fnName,
+    contractId,
+    ...opArgs,
+  };
+};

--- a/@stellar/typescript-wallet-sdk-soroban/src/Types/index.ts
+++ b/@stellar/typescript-wallet-sdk-soroban/src/Types/index.ts
@@ -1,0 +1,16 @@
+// https://github.com/stellar/soroban-examples/blob/main/token/src/contract.rs
+export enum SorobanTokenInterface {
+  transfer = "transfer",
+  mint = "mint",
+}
+
+export type ArgsForTokenInvocation = {
+  from: string;
+  to: string;
+  amount: bigint | number;
+};
+
+export type TokenInvocationArgs = ArgsForTokenInvocation & {
+  fnName: SorobanTokenInterface;
+  contractId: string;
+};

--- a/@stellar/typescript-wallet-sdk-soroban/src/index.ts
+++ b/@stellar/typescript-wallet-sdk-soroban/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./Helpers";
+export * from "./Types";

--- a/@stellar/typescript-wallet-sdk-soroban/test/helpers.test.ts
+++ b/@stellar/typescript-wallet-sdk-soroban/test/helpers.test.ts
@@ -1,0 +1,75 @@
+import {
+  Memo,
+  MemoType,
+  Networks,
+  Operation,
+  Transaction,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
+
+import { SorobanTokenInterface, getTokenInvocationArgs } from "../src";
+
+const transactions = {
+  classic:
+    "AAAAAgAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAGQABqQMAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAAAAmJaAAAAAAAAAAAFw7E5LAAAAQBu4V+/lttEONNM6KFwdSf5TEEogyEBy0jTOHJKuUzKScpLHyvDJGY+xH9Ri4cIuA7AaB8aL+VdlucCfsNYpKAY=",
+  sorobanTransfer:
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucaFsAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAjOiEfRh4kaFVQDu/CSTZLMtnyg0DbNowZ/G2nLES3KwAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtysAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAACAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrAAAAAEAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOgWXYAJP0dmRsJ65pP0wAh1K2l1/nzAzc/bieXvfwCdAAAAAQBkcwsAACBwAAABKAAAAAAAAB1kAAAAAA==",
+  sorobanMint:
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucQIQAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAEbWludAAAAAIAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAABG1pbnQAAAACAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAABAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAEAYpBIAAAfrAAAAJQAAAAAAAAdYwAAAAA=",
+};
+
+describe("Soroban Helpers", () => {
+  it("get token invocation args for Soroban transfer (payment) operation", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      transactions.sorobanTransfer,
+      Networks.FUTURENET,
+    ) as Transaction<Memo<MemoType>, Operation.InvokeHostFunction[]>;
+    const op = transaction.operations[0];
+
+    const args = getTokenInvocationArgs(op);
+
+    expect(args.fnName).toBe(SorobanTokenInterface.transfer);
+    expect(args.contractId).toBe(
+      "CAPECFLUT6KHYOOWUQNP7KC6PTMICKANBURFWRMPZTXUEEKHN67B7UI2",
+    );
+    expect(args.from).toBe(
+      "GCGORBD5DB4JDIKVIA536CJE3EWMWZ6KBUBWZWRQM7Y3NHFRCLOKYVAL",
+    );
+    expect(args.to).toBe(
+      "GDUBMXMABE7UOZSGYJ5ONE7UYAEHKK3JOX7HZQGNZ7NYTZPPP4AJ2GQJ",
+    );
+    expect(args.amount === BigInt(5)).toBeTruthy();
+  });
+
+  it("get token invocation args for Soroban mint operation", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      transactions.sorobanMint,
+      Networks.FUTURENET,
+    ) as Transaction<Memo<MemoType>, Operation.InvokeHostFunction[]>;
+    const op = transaction.operations[0];
+
+    const args = getTokenInvocationArgs(op);
+
+    expect(args.fnName).toBe(SorobanTokenInterface.mint);
+    expect(args.contractId).toBe(
+      "CAPECFLUT6KHYOOWUQNP7KC6PTMICKANBURFWRMPZTXUEEKHN67B7UI2",
+    );
+    expect(args.from).toBe("");
+    expect(args.to).toBe(
+      "GDUBMXMABE7UOZSGYJ5ONE7UYAEHKK3JOX7HZQGNZ7NYTZPPP4AJ2GQJ",
+    );
+    expect(args.amount === BigInt(5)).toBeTruthy();
+  });
+
+  it("stellar classic transaction should have no token invocation args", () => {
+    const transaction = TransactionBuilder.fromXDR(
+      transactions.classic,
+      Networks.TESTNET,
+    ) as Transaction<Memo<MemoType>, Operation.InvokeHostFunction[]>;
+    const op = transaction.operations[0];
+
+    const args = getTokenInvocationArgs(op);
+
+    expect(args).toBe(null);
+  });
+});

--- a/@stellar/typescript-wallet-sdk-soroban/test/tsconfig.json
+++ b/@stellar/typescript-wallet-sdk-soroban/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "baseUrl": "./",
+    "outDir": "lib",
+    "declaration": true,
+    "declarationDir": "lib"
+  },
+  "include": ["./"]
+}

--- a/@stellar/typescript-wallet-sdk-soroban/tsconfig.json
+++ b/@stellar/typescript-wallet-sdk-soroban/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "baseUrl": "src/",
+    "outDir": "lib",
+    "declaration": true,
+    "declarationDir": "lib"
+  },
+  "include": ["src"]
+}

--- a/@stellar/typescript-wallet-sdk-soroban/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk-soroban/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require("path");
+const webpack = require("webpack");
+
+module.exports = (env = { NODE: false }) => {
+  const isBrowser = !env.NODE;
+
+  return {
+    mode: "development",
+    entry: "./src/index.ts",
+    devtool: "source-map",
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: "ts-loader",
+          exclude: /node_modules/,
+        },
+      ],
+    },
+    resolve: {
+      extensions: [".js", ".json", ".ts"],
+      fallback: isBrowser
+        ? {
+            crypto: require.resolve("crypto-browserify"),
+            http: require.resolve("stream-http"),
+            https: require.resolve("https-browserify"),
+            stream: require.resolve("stream-browserify"),
+            url: require.resolve("url"),
+            util: require.resolve("util"),
+            vm: require.resolve("vm-browserify"),
+            "process/browser": require.resolve("process/browser"),
+          }
+        : {},
+    },
+    output: {
+      library: "WalletSDK",
+      libraryTarget: "umd",
+      globalObject: "this",
+      filename: `bundle${isBrowser ? "_browser" : ""}.js`,
+      path: path.resolve(__dirname, "lib"),
+    },
+    target: isBrowser ? "web" : "node",
+    plugins: isBrowser
+      ? [
+          new webpack.ProvidePlugin({
+            process: "process/browser",
+          }),
+        ]
+      : [],
+  };
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,5 +18,11 @@ module.exports = {
       testPathIgnorePatterns: ["/node_modules/"],
       ...commonConfigs,
     },
+    {
+      displayName: "Wallet SDK Soroban",
+      roots: ["./@stellar/typescript-wallet-sdk-soroban"],
+      testPathIgnorePatterns: ["/node_modules/"],
+      ...commonConfigs,
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "main": ".eslintrc.js",
   "workspaces": [
     "@stellar/typescript-wallet-sdk",
-    "@stellar/typescript-wallet-sdk-km"
+    "@stellar/typescript-wallet-sdk-km",
+    "@stellar/typescript-wallet-sdk-soroban"
   ],
   "scripts": {
     "prepare": "husky install",
@@ -12,7 +13,7 @@
     "test:ci": "jest --ci",
     "test:recovery:ci": "yarn workspace @stellar/typescript-wallet-sdk test:recovery:ci",
     "test:anchorplatform:ci": "yarn workspace @stellar/typescript-wallet-sdk test:anchorplatform:ci",
-    "build": "yarn workspace @stellar/typescript-wallet-sdk build && yarn workspace @stellar/typescript-wallet-sdk-km build"
+    "build": "yarn workspace @stellar/typescript-wallet-sdk build && yarn workspace @stellar/typescript-wallet-sdk-km build && yarn workspace @stellar/typescript-wallet-sdk-soroban build"
   },
   "lint-staged": {
     "**/*.ts": [


### PR DESCRIPTION
Ported from https://github.com/stellar/typescript-wallet-sdk/pull/105

Related task: https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37/backlog?selectedIssue=WAL-1365

This PR adds the `getTokenInvocationArgs` function in a separate `@stellar/typescript-wallet-sdk-soroban` workspace.

The GH Action workflow and README files for this new workspace will be pushed in separate PR after this one is merged.