### PR TITLE
Use relative path to access "walletSdk" root folder

### DIFF
--- a/@stellar/typescript-wallet-sdk/examples/sep24/sep24.ts
+++ b/@stellar/typescript-wallet-sdk/examples/sep24/sep24.ts
@@ -9,6 +9,7 @@ import {
   Types,
   IssuedAssetId,
   DefaultSigner,
+  Wallet,
 } from "../../src";
 import {
   Memo,
@@ -34,7 +35,7 @@ const clientSecret = process.env.CLIENT_SECRET;
 
 // Running example
 
-let wallet;
+let wallet: Wallet;
 if (runMainnet === "true") {
   console.log("Warning: you are running this script on the public network.");
   wallet = walletSdk.Wallet.MainNet();
@@ -123,7 +124,6 @@ export let depositDone = false;
 export const runDepositWatcher = (anchor: Anchor) => {
   console.log("\nstarting watcher ...");
 
-  const stop: Types.WatcherStopFunction;
   const onMessage = (m: Types.AnchorTransaction) => {
     console.log({ m });
     if (m.status === Types.TransactionStatus.completed) {
@@ -138,7 +138,7 @@ export const runDepositWatcher = (anchor: Anchor) => {
   };
 
   const watcher = anchor.sep24().watcher();
-  const resp = watcher.watchAllTransactions({
+  const { stop } = watcher.watchAllTransactions({
     authToken: authToken,
     assetCode: asset.code,
     onMessage,
@@ -146,8 +146,6 @@ export const runDepositWatcher = (anchor: Anchor) => {
     timeout: 5000,
     lang: "en-US",
   });
-
-  stop = resp.stop;
 };
 
 // Create Withdrawal
@@ -188,7 +186,6 @@ const sendWithdrawalTransaction = async (withdrawalTxn, kp) => {
 export const runWithdrawWatcher = (anchor, kp) => {
   console.log("\nstarting watcher ...");
 
-  const stop;
   const onMessage = (m) => {
     console.log({ m });
 
@@ -208,7 +205,7 @@ export const runWithdrawWatcher = (anchor, kp) => {
   };
 
   const watcher = anchor.sep24().watcher();
-  const resp = watcher.watchAllTransactions({
+  const { stop } = watcher.watchAllTransactions({
     authToken: authToken,
     assetCode: asset.code,
     onMessage,
@@ -216,8 +213,6 @@ export const runWithdrawWatcher = (anchor, kp) => {
     timeout: 5000,
     lang: "en-US",
   });
-
-  stop = resp.stop;
 };
 
 const walletSigner = DefaultSigner;

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
 import { StellarToml } from "@stellar/stellar-sdk";
 
-import { Config } from "walletSdk";
+import { Config } from "../";
 import { Sep10 } from "../Auth";
 import { Sep12 } from "../Customer";
 import {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
@@ -2,7 +2,7 @@ import { AxiosInstance } from "axios";
 import { TransactionBuilder, Transaction } from "@stellar/stellar-sdk";
 import { decode } from "jws";
 
-import { Config } from "walletSdk";
+import { Config } from "../";
 import {
   InvalidMemoError,
   ClientDomainWithMemoError,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/AccountService.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/AccountService.ts
@@ -1,6 +1,6 @@
 import { Keypair, Networks, Horizon } from "@stellar/stellar-sdk";
 
-import { Config } from "walletSdk";
+import { Config } from "../";
 import { SigningKeypair } from "./Account";
 import {
   HORIZON_LIMIT_DEFAULT,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Stellar.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Stellar.ts
@@ -7,7 +7,7 @@ import {
 } from "@stellar/stellar-sdk";
 import axios from "axios";
 
-import { Config } from "walletSdk";
+import { Config } from "../";
 import { AccountService } from "./AccountService";
 import { TransactionBuilder } from "./Transaction/TransactionBuilder";
 import {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
@@ -8,7 +8,7 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
-import { Config } from "walletSdk";
+import { Config } from "../../";
 import { AccountKeypair } from "../Account";
 import {
   InsufficientStartingBalanceError,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Recovery/AccountRecover.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Recovery/AccountRecover.ts
@@ -7,7 +7,7 @@ import {
   RecoveryServerMap,
   RecoveryServerSigning,
   RecoveryServerSigningMap,
-} from "walletSdk/Types";
+} from "../Types";
 import {
   LostSignerKeyNotFound,
   NoDeviceKeyForAccountError,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Recovery/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Recovery/index.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
 import { Transaction } from "@stellar/stellar-sdk";
 
-import { Config } from "walletSdk";
+import { Config } from "../";
 import {
   AccountSigner,
   AccountThreshold,
@@ -16,7 +16,7 @@ import {
   RecoveryIdentityMap,
   RecoveryServerKey,
   RecoveryServerMap,
-} from "walletSdk/Types";
+} from "../Types";
 import { AccountRecover } from "./AccountRecover";
 import { Sep10 } from "../Auth";
 import {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/horizon.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/horizon.ts
@@ -1,6 +1,6 @@
 import { Memo, Horizon, Transaction } from "@stellar/stellar-sdk";
 import { AccountKeypair } from "../Horizon/Account";
-import { SponsoringBuilder, TransactionBuilder } from "walletSdk/Horizon";
+import { SponsoringBuilder, TransactionBuilder } from "../Horizon";
 import { StellarAssetId } from "../Asset";
 
 export enum NETWORK_URLS {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/index.ts
@@ -1,6 +1,6 @@
 import { RawAxiosRequestHeaders } from "axios";
 import { Networks } from "@stellar/stellar-sdk";
-import { ApplicationConfiguration, StellarConfiguration } from "walletSdk";
+import { ApplicationConfiguration, StellarConfiguration } from "../";
 import { RecoveryServerMap } from "./recovery";
 
 // Export types from root walletSdk/index.ts

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/recovery.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/recovery.ts
@@ -1,7 +1,7 @@
 import { Transaction } from "@stellar/stellar-sdk";
 
-import { WalletSigner } from "walletSdk/Auth";
-import { AccountKeypair, PublicKeypair } from "walletSdk/Horizon";
+import { WalletSigner } from "../Auth";
+import { AccountKeypair, PublicKeypair } from "../Horizon";
 import { AuthToken } from "./auth";
 import { CommonBuilder } from "./horizon";
 


### PR DESCRIPTION
For some reason accessing it with absolute `"walletSdk"` path is throwing `Cannot find module 'walletSdk' or its corresponding type declarations.` in several places while running `yarn example:sep24`.

Using a relative path like `"../"` fixes the issue.

<img width="1099" alt="Screenshot 2024-04-11 at 17 00 48" src="https://github.com/stellar/typescript-wallet-sdk/assets/3228151/238a8ef4-d18b-48b3-a5b5-d2d694b91570">