### PR TITLE
Updates BrowserStorageConfigParams method types

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/src/Plugins/BrowserStorageFacade.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/Plugins/BrowserStorageFacade.ts
@@ -3,9 +3,11 @@ import { EncryptedKey } from "../Types";
 export interface BrowserStorageConfigParams {
   prefix?: string;
   storage: {
-    get: (key?: string | string[] | object) => Promise<object>;
+    get: (
+      key?: null | string | string[] | Record<string, unknown>,
+    ) => Promise<Record<string, unknown>>;
     remove: (key: string | string[]) => Promise<void>;
-    set: (items: object) => Promise<object>;
+    set: (items: Record<string, unknown>) => Promise<void>;
   };
 }
 


### PR DESCRIPTION
What
Updates the `BrowserStorageConfigParams` to match [the previous definition](https://github.com/stellar/js-stellar-wallets/blob/5ccb6e8a4bfb26c7254aa4e963600f91da122bc0/src/plugins/BrowserStorageFacade.ts#L3C18-L3C44) and the [webkit polyfill's definition](https://github.com/mozilla/webextension-polyfill/blob/master/src/browser-polyfill.js)

Why
While migrating from `@stellar/wallet-sdk`, I hit a type error because storage API definitions clash.
https://github.com/stellar/freighter/pull/1255