### PR TITLE
[TS] Implement support for SEP-7

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/index.ts
@@ -33,6 +33,15 @@ export {
   SponsoringBuilder,
 } from "./walletSdk/Horizon";
 export { Recovery } from "./walletSdk/Recovery";
+export {
+  Sep7Base,
+  Sep7Pay,
+  Sep7Tx,
+  isValidSep7Uri,
+  parseSep7Uri,
+  sep7ReplacementsFromString,
+  sep7ReplacementsToString,
+} from "./walletSdk/Uri";
 export { Watcher } from "./walletSdk/Watcher";
 
 /**

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/WalletSigner.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/WalletSigner.ts
@@ -10,6 +10,7 @@ import {
   HttpHeaders,
 } from "../Types";
 import { DefaultClient } from "../";
+import { DefaultSignerDomainAccountError } from "../Exceptions";
 
 /**
  * A Wallet Signer for signing Stellar transactions.
@@ -51,9 +52,8 @@ export const DefaultSigner: WalletSigner = {
   },
   // eslint-disable-next-line @typescript-eslint/require-await
   signWithDomainAccount: async () => {
-    throw new Error(
-      "The DefaultSigner can't sign transactions with domain account",
-    );
+    // The DefaultSigner can't sign transactions with domain account
+    throw new DefaultSignerDomainAccountError();
   },
 };
 

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
@@ -17,10 +17,10 @@ import {
  * @class
  */
 export class Sep12 {
-  private authToken;
-  private baseUrl;
-  private httpClient;
-  private headers;
+  private authToken: AuthToken;
+  private baseUrl: string;
+  private httpClient: AxiosInstance;
+  private headers: { [key: string]: string };
 
   /**
    * Creates a new instance of the Sep12 class.

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -341,12 +341,12 @@ export class AuthHeaderClientDomainRequiredError extends Error {
   }
 }
 
-export class InvalidSep7UriError extends Error {
+export class Sep7InvalidUriError extends Error {
   constructor() {
     super(
       `Invalid Stellar Sep-7 URI: it must either start with '${WEB_STELLAR_TX_SCHEME}' and have a 'xdr' param or start with '${WEB_STELLAR_PAY_SCHEME}' and have a 'destination' param`,
     );
-    Object.setPrototypeOf(this, InvalidSep7UriError.prototype);
+    Object.setPrototypeOf(this, Sep7InvalidUriError.prototype);
   }
 }
 

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -308,6 +308,20 @@ export class InvalidJsonError extends Error {
   }
 }
 
+export class SigningKeypairMissingSecretError extends Error {
+  constructor() {
+    super("This keypair doesn't have a secret key and can't sign");
+    Object.setPrototypeOf(this, SigningKeypairMissingSecretError.prototype);
+  }
+}
+
+export class DefaultSignerDomainAccountError extends Error {
+  constructor() {
+    super("The DefaultSigner can't sign transactions with domain account");
+    Object.setPrototypeOf(this, DefaultSignerDomainAccountError.prototype);
+  }
+}
+
 export class AuthHeaderSigningKeypairRequiredError extends Error {
   constructor() {
     super("Must be SigningKeypair to sign auth header");

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -5,6 +5,8 @@ import {
   FLOW_TYPE,
   AxiosErrorData,
   GetCustomerParams,
+  WEB_STELLAR_TX_SCHEME,
+  WEB_STELLAR_PAY_SCHEME,
 } from "../Types";
 import { extractAxiosErrorData } from "../Utils";
 
@@ -322,5 +324,28 @@ export class AuthHeaderClientDomainRequiredError extends Error {
       "This class should only be used for remote signing. For local signing use DefaultAuthHeaderSigner.",
     );
     Object.setPrototypeOf(this, AuthHeaderClientDomainRequiredError.prototype);
+  }
+}
+
+export class InvalidSep7UriError extends Error {
+  constructor() {
+    super(
+      `Invalid Stellar Sep-7 URI: it must either start with '${WEB_STELLAR_TX_SCHEME}' and have a 'xdr' param or start with '${WEB_STELLAR_PAY_SCHEME}' and have a 'destination' param`,
+    );
+    Object.setPrototypeOf(this, InvalidSep7UriError.prototype);
+  }
+}
+
+export class Sep7LongMsgError extends Error {
+  constructor(msgMaxLength: number) {
+    super(`'msg' should be no longer than ${msgMaxLength} characters.`);
+    Object.setPrototypeOf(this, Sep7LongMsgError.prototype);
+  }
+}
+
+export class Sep7UriTypeNotSupportedError extends Error {
+  constructor(type: string) {
+    super(`Stellar Sep-7 URI type ${type} is not currently supported.`);
+    Object.setPrototypeOf(this, Sep7UriTypeNotSupportedError.prototype);
   }
 }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -5,8 +5,6 @@ import {
   FLOW_TYPE,
   AxiosErrorData,
   GetCustomerParams,
-  WEB_STELLAR_TX_SCHEME,
-  WEB_STELLAR_PAY_SCHEME,
 } from "../Types";
 import { extractAxiosErrorData } from "../Utils";
 
@@ -335,31 +333,31 @@ export class AuthHeaderSigningKeypairRequiredError extends Error {
 export class AuthHeaderClientDomainRequiredError extends Error {
   constructor() {
     super(
-      "This class should only be used for remote signing. For local signing use DefaultAuthHeaderSigner.",
+      "This class should only be used for remote signing. For local signing use DefaultAuthHeaderSigner",
     );
     Object.setPrototypeOf(this, AuthHeaderClientDomainRequiredError.prototype);
   }
 }
 
 export class Sep7InvalidUriError extends Error {
-  constructor() {
-    super(
-      `Invalid Stellar Sep-7 URI: it must either start with '${WEB_STELLAR_TX_SCHEME}' and have a 'xdr' param or start with '${WEB_STELLAR_PAY_SCHEME}' and have a 'destination' param`,
-    );
+  constructor(reason: string) {
+    super(`Invalid Stellar Sep-7 URI, reason: ${reason}`);
     Object.setPrototypeOf(this, Sep7InvalidUriError.prototype);
   }
 }
 
 export class Sep7LongMsgError extends Error {
   constructor(msgMaxLength: number) {
-    super(`'msg' should be no longer than ${msgMaxLength} characters.`);
+    super(`'msg' should be no longer than ${msgMaxLength} characters`);
     Object.setPrototypeOf(this, Sep7LongMsgError.prototype);
   }
 }
 
 export class Sep7UriTypeNotSupportedError extends Error {
   constructor(type: string) {
-    super(`Stellar Sep-7 URI type ${type} is not currently supported.`);
+    super(
+      `Stellar Sep-7 URI operation type '${type}' is not currently supported`,
+    );
     Object.setPrototypeOf(this, Sep7UriTypeNotSupportedError.prototype);
   }
 }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Account.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Account.ts
@@ -1,4 +1,5 @@
 import { Keypair, Transaction, FeeBumpTransaction } from "@stellar/stellar-sdk";
+import { SigningKeypairMissingSecretError } from "../Exceptions";
 
 export class AccountKeypair {
   keypair: Keypair;
@@ -28,7 +29,7 @@ export class PublicKeypair extends AccountKeypair {
 export class SigningKeypair extends AccountKeypair {
   constructor(keypair: Keypair) {
     if (!keypair.canSign()) {
-      throw new Error("This keypair doesn't have a secret key and can't sign");
+      throw new SigningKeypairMissingSecretError();
     }
     super(keypair);
   }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/index.ts
@@ -46,6 +46,7 @@ export * from "./auth";
 export * from "./horizon";
 export * from "./recovery";
 export * from "./sep6";
+export * from "./sep7";
 export * from "./sep12";
 export * from "./sep24";
 export * from "./sep38";

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
@@ -1,11 +1,9 @@
+export const WEB_STELLAR_SCHEME = "web+stellar:";
+
 export enum Sep7OperationType {
   tx = "tx",
   pay = "pay",
 }
-
-export const WEB_STELLAR_SCHEME = "web+stellar:";
-export const WEB_STELLAR_TX_SCHEME = `${WEB_STELLAR_SCHEME}${Sep7OperationType.tx}`;
-export const WEB_STELLAR_PAY_SCHEME = `${WEB_STELLAR_SCHEME}${Sep7OperationType.pay}`;
 
 export const URI_MSG_MAX_LENGTH = 300;
 
@@ -13,4 +11,9 @@ export type Sep7Replacement = {
   id: string;
   path: string;
   hint: string;
+};
+
+export type IsValidSep7UriResult = {
+  result: boolean;
+  reason?: string;
 };

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
@@ -1,0 +1,16 @@
+export enum Sep7OperationType {
+  tx = "tx",
+  pay = "pay",
+}
+
+export const WEB_STELLAR_SCHEME = "web+stellar:";
+export const WEB_STELLAR_TX_SCHEME = `${WEB_STELLAR_SCHEME}${Sep7OperationType.tx}`;
+export const WEB_STELLAR_PAY_SCHEME = `${WEB_STELLAR_SCHEME}${Sep7OperationType.pay}`;
+
+export const URI_MSG_MAX_LENGTH = 300;
+
+export type Sep7Replacement = {
+  id: string;
+  path: string;
+  hint: string;
+};

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
@@ -1,0 +1,153 @@
+import { Keypair, Networks, StellarToml } from "@stellar/stellar-sdk";
+import { Sep7OperationType, URI_MSG_MAX_LENGTH } from "../Types";
+import { Sep7LongMsgError } from "../Exceptions";
+
+/**
+ *
+ */
+export abstract class Sep7Base {
+  protected uri: URL;
+
+  /**
+   * Creates a new instance of the Sep7 class.
+   *
+   * @constructor
+   * @param {URL | string} uri - uri to initialize the Sep7 instance.
+   */
+  constructor(uri: URL | string) {
+    this.uri = new URL(uri.toString());
+
+    if (this.msg?.length > URI_MSG_MAX_LENGTH) {
+      throw new Sep7LongMsgError(URI_MSG_MAX_LENGTH);
+    }
+  }
+
+  abstract clone(): Sep7Base;
+
+  get operationType(): Sep7OperationType {
+    return this.uri.pathname as Sep7OperationType;
+  }
+
+  get callback(): string | undefined {
+    const callback = this.getParam("callback");
+
+    if (callback?.startsWith("url:")) {
+      return callback.replace("url:", "");
+    }
+
+    return callback;
+  }
+
+  set callback(callback: string | undefined) {
+    if (!callback) {
+      this.setParam("callback", undefined);
+      return;
+    }
+
+    if (callback.startsWith("url:")) {
+      this.setParam("callback", callback);
+      return;
+    }
+
+    this.setParam("callback", `url:${callback}`);
+  }
+
+  get msg(): string | undefined {
+    return this.getParam("msg");
+  }
+
+  set msg(msg: string | undefined) {
+    if (msg?.length > URI_MSG_MAX_LENGTH) {
+      throw new Sep7LongMsgError(URI_MSG_MAX_LENGTH);
+    }
+
+    this.setParam("msg", msg);
+  }
+
+  get networkPassphrase(): Networks {
+    return (this.getParam("network_passphrase") ?? Networks.PUBLIC) as Networks;
+  }
+
+  set networkPassphrase(networkPassphrase: Networks | undefined) {
+    this.setParam("network_passphrase", networkPassphrase);
+  }
+
+  get originDomain(): string | undefined {
+    return this.getParam("origin_domain");
+  }
+
+  set originDomain(domain: string | undefined) {
+    this.setParam("origin_domain", domain);
+  }
+
+  get signature(): string | undefined {
+    return this.getParam("signature");
+  }
+
+  addSignature(keypair: Keypair): string {
+    const payload = this.createSignaturePayload();
+    const signature = keypair.sign(payload).toString("base64");
+    this.setParam("signature", signature);
+    return signature;
+  }
+
+  async verifySignature(): Promise<boolean> {
+    const originDomain = this.originDomain;
+    const signature = this.signature;
+
+    // we can fail fast if neither of them are set since we can't verify without both
+    if (!originDomain || !signature) {
+      return false;
+    }
+
+    try {
+      const toml = await StellarToml.Resolver.resolve(originDomain);
+      const signingKey = toml.URI_REQUEST_SIGNING_KEY;
+
+      if (!signingKey) {
+        return false;
+      }
+      const keypair = Keypair.fromPublicKey(signingKey);
+      const payload = this.createSignaturePayload();
+      return keypair.verify(payload, Buffer.from(signature, "base64"));
+    } catch (e) {
+      // if something fails we assume signature verification failed
+      return false;
+    }
+  }
+
+  toString(): string {
+    return this.uri.toString();
+  }
+
+  protected getParam(key: string): string | undefined {
+    return this.uri.searchParams.get(key) || undefined;
+  }
+
+  protected setParam(key: string, value: string | undefined) {
+    if (!value) {
+      this.uri.searchParams.delete(key);
+      return;
+    }
+
+    // this searchParams.set() function automatically applies URL encoding
+    this.uri.searchParams.set(key, value);
+  }
+
+  private createSignaturePayload(): Buffer {
+    let data = this.toString();
+
+    const signature = this.signature;
+    if (signature) {
+      // the payload must be created without the signature on it
+      data = data.replace(`&signature=${encodeURIComponent(signature)}`, "");
+    }
+
+    // https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#request-signing
+    return Buffer.concat([
+      Buffer.alloc(35, 0),
+      Buffer.alloc(1, 4),
+      Buffer.from(`stellar.sep.7 - URI Scheme${data}`),
+    ]);
+  }
+}

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
@@ -3,7 +3,10 @@ import { Sep7OperationType, URI_MSG_MAX_LENGTH } from "../Types";
 import { Sep7LongMsgError } from "../Exceptions";
 
 /**
+ * A base abstract class containing common functions that should be used by both
+ * Sep7Tx and Sep7Pay classes for parsing or constructing SEP-0007 Stellar URIs.
  *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#specification
  */
 export abstract class Sep7Base {
   protected uri: URL;
@@ -22,12 +25,40 @@ export abstract class Sep7Base {
     }
   }
 
+  /**
+   * Should return a deep clone of this instance.
+   *
+   * @returns {Sep7Base} a deep clone of the Sep7Base extended instance.
+   */
   abstract clone(): Sep7Base;
 
+  /**
+   * Returns a stringfied URL-decoded version of the 'uri' object.
+   *
+   * @returns {string} the uri decoded string value.
+   */
+  toString(): string {
+    return this.uri.toString();
+  }
+
+  /**
+   * Returns uri's pathname as the operation type.
+   *
+   * @returns {Sep7OperationType} the operation type, either "tx" or "pay".
+   */
   get operationType(): Sep7OperationType {
     return this.uri.pathname as Sep7OperationType;
   }
 
+  /**
+   * Returns a URL-decoded version of the uri 'callback' param without
+   * the 'url:' prefix.
+   *
+   * The URI handler should send the signed XDR to this callback url, if this
+   * value is omitted then the URI handler should submit it to the network.
+   *
+   * @returns {string | undefined} URL-decoded 'callback' param if present.
+   */
   get callback(): string | undefined {
     const callback = this.getParam("callback");
 
@@ -38,6 +69,17 @@ export abstract class Sep7Base {
     return callback;
   }
 
+  /**
+   * Sets and URL-encodes the uri 'callback' param, appends the 'url:'
+   * prefix to it if not yet present.
+   *
+   * Deletes the uri 'callback' param if set as 'undefined'.
+   *
+   * The URI handler should send the signed XDR to this callback url, if this
+   * value is omitted then the URI handler should submit it to the network.
+   *
+   * @param {string | undefined} callback the uri 'callback' param to be set.
+   */
   set callback(callback: string | undefined) {
     if (!callback) {
       this.setParam("callback", undefined);
@@ -52,10 +94,30 @@ export abstract class Sep7Base {
     this.setParam("callback", `url:${callback}`);
   }
 
+  /**
+   * Returns a URL-decoded version of the uri 'msg' param.
+   *
+   * This message should indicate any additional information that the website
+   * or application wants to show the user in her wallet.
+   *
+   * @returns {string | undefined} URL-decoded 'msg' param if present.
+   */
   get msg(): string | undefined {
     return this.getParam("msg");
   }
 
+  /**
+   * Sets and URL-encodes the uri 'msg' param, the 'msg' param can't
+   * be larger than 300 characters.
+   *
+   * Deletes the uri 'msg' param if set as 'undefined'.
+   *
+   * This message should indicate any additional information that the website
+   * or application wants to show the user in her wallet.
+   *
+   * @param {string | undefined} msg the uri 'msg' param to be set.
+   * @throws {Sep7LongMsgError} if 'msg' length is bigger than 300.
+   */
   set msg(msg: string | undefined) {
     if (msg?.length > URI_MSG_MAX_LENGTH) {
       throw new Sep7LongMsgError(URI_MSG_MAX_LENGTH);
@@ -64,26 +126,88 @@ export abstract class Sep7Base {
     this.setParam("msg", msg);
   }
 
+  /**
+   * Returns uri 'network_passphrase' param, if not present returns
+   * the PUBLIC Network value by default: 'Public Global Stellar Network ; September 2015'.
+   *
+   * @returns {Networks} the Stellar network passphrase considered for this uri.
+   */
   get networkPassphrase(): Networks {
     return (this.getParam("network_passphrase") ?? Networks.PUBLIC) as Networks;
   }
 
+  /**
+   * Sets the uri 'network_passphrase' param.
+   *
+   * Deletes the uri 'network_passphrase' param if set as 'undefined'.
+   *
+   * Only need to set it if this transaction is for a network other than
+   * the public network.
+   *
+   * @param {Networks | undefined} networkPassphrase the uri 'network_passphrase'
+   * param to be set.
+   */
   set networkPassphrase(networkPassphrase: Networks | undefined) {
     this.setParam("network_passphrase", networkPassphrase);
   }
 
+  /**
+   * Returns a URL-decoded version of the uri 'origin_domain' param.
+   *
+   * This should be a fully qualified domain name that specifies the originating
+   * domain of the URI request.
+   *
+   * @returns {string | undefined} URL-decoded 'origin_domain' param if present.
+   */
   get originDomain(): string | undefined {
     return this.getParam("origin_domain");
   }
 
-  set originDomain(domain: string | undefined) {
-    this.setParam("origin_domain", domain);
+  /**
+   * Sets and URL-encodes the uri 'origin_domain' param.
+   *
+   * Deletes the uri 'origin_domain' param if set as 'undefined'.
+   *
+   * This should be a fully qualified domain name that specifies the originating
+   * domain of the URI request.
+   *
+   * @param {string | undefined} originDomain the uri 'origin_domain' param
+   * to be set.
+   */
+  set originDomain(originDomain: string | undefined) {
+    this.setParam("origin_domain", originDomain);
   }
 
+  /**
+   * Returns a URL-decoded version of the uri 'signature' param.
+   *
+   * This should be a signature of the hash of the URI request (excluding the
+   * 'signature' field and value itself).
+   *
+   * Wallets should use the URI_REQUEST_SIGNING_KEY specified in the
+   * origin_domain's stellar.toml file to validate this signature.
+   * If the verification fails, wallets must alert the user.
+   *
+   * @returns {string | undefined} URL-decoded 'signature' param if present.
+   */
   get signature(): string | undefined {
     return this.getParam("signature");
   }
 
+  /**
+   * Signs the URI with the given keypair, which means it sets the 'signature' param.
+   *
+   * This should be the last step done before generating the URI string,
+   * otherwise the signature will be invalid for the URI.
+   *
+   * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#request-signing
+   *
+   * @param {Keypair} keypair The keypair (including secret key), used to sign the request.
+   * This should be the keypair found in the URI_REQUEST_SIGNING_KEY field of the
+   * origin_domains' stellar.toml.
+   *
+   * @returns {string} the generated 'signature' param.
+   */
   addSignature(keypair: Keypair): string {
     const payload = this.createSignaturePayload();
     const signature = keypair.sign(payload).toString("base64");
@@ -91,6 +215,16 @@ export abstract class Sep7Base {
     return signature;
   }
 
+  /**
+   * Verifies that the signature added to the URI is valid.
+   *
+   * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#request-signing
+   *
+   * @returns {Promise<boolean>} returns 'true' if the signature is valid for
+   * the current URI and origin_domain. Returns 'false' if signature verification
+   * fails, or if there is a problem looking up the stellar.toml associated with
+   * the origin_domain.
+   */
   async verifySignature(): Promise<boolean> {
     const originDomain = this.originDomain;
     const signature = this.signature;
@@ -116,24 +250,46 @@ export abstract class Sep7Base {
     }
   }
 
-  toString(): string {
-    return this.uri.toString();
-  }
-
+  /**
+   * Finds the uri param related to the inputted 'key', if any, and returns
+   * a URL-decoded version of it. Returns 'undefined' if key param not found.
+   *
+   * @param {string} key the uri param key.
+   *
+   * @returns {string | undefined} URL-decoded value of the uri param if found.
+   */
   protected getParam(key: string): string | undefined {
+    // the searchParams.get() function automatically applies URL dencoding.
     return this.uri.searchParams.get(key) || undefined;
   }
 
+  /**
+   * Sets and URL-encodes a 'key=value' uri param.
+   *
+   * Deletes the uri param if 'value' set as 'undefined'.
+   *
+   * @param {string} key the uri param key.
+   * @param {string | undefined} value the uri param value to be set.
+   */
   protected setParam(key: string, value: string | undefined) {
     if (!value) {
       this.uri.searchParams.delete(key);
       return;
     }
 
-    // this searchParams.set() function automatically applies URL encoding
+    // the searchParams.set() function automatically applies URL encoding.
     this.uri.searchParams.set(key, value);
   }
 
+  /**
+   * Converts the URI request into the payload that will be signed by
+   * the 'addSignature' method.
+   *
+   * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#request-signing
+   *
+   * @returns {Buffer} array of bytes to be signed with given keypair on
+   * the 'addSignature' method.
+   */
   private createSignaturePayload(): Buffer {
     let data = this.toString();
 
@@ -143,7 +299,9 @@ export abstract class Sep7Base {
       data = data.replace(`&signature=${encodeURIComponent(signature)}`, "");
     }
 
-    // https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#request-signing
+    // The first 35 bytes of the payload are all 0, the 36th byte is 4.
+    // Then we concatenate the URI request with the prefix 'stellar.sep.7 - URI Scheme'
+    // (no delimiter) and convert that to bytes to give use the final payload to be signed.
     return Buffer.concat([
       Buffer.alloc(35, 0),
       Buffer.alloc(1, 4),

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
@@ -26,7 +26,7 @@ export class Sep7Pay extends Sep7Base {
    * Creates a new instance of the Sep7Pay class.
    *
    * @constructor
-   * @param {URL | string} uri - uri to initialize the Sep7 instance.
+   * @param {URL | string} [uri] - uri to initialize the Sep7 instance.
    */
   constructor(uri?: URL | string) {
     super(uri ?? new URL(WEB_STELLAR_PAY_SCHEME));

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
@@ -1,6 +1,6 @@
 import { MemoType } from "@stellar/stellar-sdk";
 import { Sep7Base } from "../Uri";
-import { WEB_STELLAR_PAY_SCHEME } from "../Types";
+import { Sep7OperationType, WEB_STELLAR_SCHEME } from "../Types";
 
 /**
  * The Sep-7 'pay' operation represents a request to pay a specific address
@@ -29,7 +29,7 @@ export class Sep7Pay extends Sep7Base {
    * @param {URL | string} [uri] - uri to initialize the Sep7 instance.
    */
   constructor(uri?: URL | string) {
-    super(uri ?? new URL(WEB_STELLAR_PAY_SCHEME));
+    super(uri ?? new URL(`${WEB_STELLAR_SCHEME}${Sep7OperationType.pay}`));
   }
 
   /**

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
@@ -3,13 +3,16 @@ import { Sep7Base } from "../Uri";
 import { WEB_STELLAR_PAY_SCHEME } from "../Types";
 
 /**
+ * The Sep-7 'pay' operation represents a request to pay a specific address
+ * with a specific asset, regardless of the source asset used by the payer.
  *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-pay
  */
 export class Sep7Pay extends Sep7Base {
   /**
    * Creates a Sep7Pay instance with given destination.
    *
-   * @param {string} destination a valid stellar address to receive the payment.
+   * @param {string} destination a valid Stellar address to receive the payment.
    *
    * @returns {Sep7Pay} the Sep7Pay instance.
    */
@@ -29,55 +32,138 @@ export class Sep7Pay extends Sep7Base {
     super(uri ?? new URL(WEB_STELLAR_PAY_SCHEME));
   }
 
+  /**
+   * Returns a deep clone of this instance.
+   *
+   * @returns {Sep7Pay} a deep clone of this Sep7Pay instance.
+   */
+  clone(): Sep7Pay {
+    return new Sep7Pay(this.uri);
+  }
+
+  /**
+   * Gets the destination of the payment request, which should be a valid
+   * Stellar address.
+   *
+   * @returns {string | undefined} the 'destination' uri param if present.
+   */
   get destination(): string | undefined {
     return this.getParam("destination");
   }
 
+  /**
+   * Sets the destination of the payment request, which should be a valid
+   * Stellar address.
+   *
+   * Deletes the uri 'destination' param if set as 'undefined'.
+   *
+   * @param {string | undefined} destination the uri 'destination' param to be set.
+   */
   set destination(destination: string | undefined) {
     this.setParam("destination", destination);
   }
 
+  /**
+   * Gets the amount that destination should receive.
+   *
+   * @returns {string | undefined} the 'amount' uri param if present.
+   */
   get amount(): string | undefined {
     return this.getParam("amount");
   }
 
+  /**
+   * Sets the amount that destination should receive.
+   *
+   * Deletes the uri 'amount' param if set as 'undefined'.
+   *
+   * @param {string | undefined} amount the uri 'amount' param to be set.
+   */
   set amount(amount: string | undefined) {
     this.setParam("amount", amount);
   }
 
+  /**
+   * Gets the code from the asset that destination should receive.
+   *
+   * @returns {string | undefined} the 'asset_code' uri param if present.
+   */
   get assetCode(): string | undefined {
     return this.getParam("asset_code");
   }
 
+  /**
+   * Sets the code from the asset that destination should receive.
+   *
+   * Deletes the uri 'asset_code' param if set as 'undefined'.
+   *
+   * @param {string | undefined} assetCode the uri 'asset_code' param to be set.
+   */
   set assetCode(assetCode: string | undefined) {
     this.setParam("asset_code", assetCode);
   }
 
+  /**
+   * Gets the account ID of asset issuer the destination should receive.
+   *
+   * @returns {string | undefined} the 'asset_issuer' uri param if present.
+   */
   get assetIssuer(): string | undefined {
     return this.getParam("asset_issuer");
   }
 
+  /**
+   * Sets the account ID of asset issuer the destination should receive.
+   *
+   * Deletes the uri 'asset_issuer' param if set as 'undefined'.
+   *
+   * @param {string | undefined} assetIssuer the uri 'asset_issuer' param to be set.
+   */
   set assetIssuer(assetIssuer: string | undefined) {
     this.setParam("asset_issuer", assetIssuer);
   }
 
+  /**
+   * Gets the memo to be included in the payment / path payment.
+   * Memos of type MEMO_HASH and MEMO_RETURN should be base64-decoded
+   * after returned from this function.
+   *
+   * @returns {string | undefined} the 'memo' uri param if present.
+   */
   get memo(): string | undefined {
     return this.getParam("memo");
   }
 
+  /**
+   * Sets the memo to be included in the payment / path payment.
+   * Memos of type MEMO_HASH and MEMO_RETURN should be base64-encoded
+   * prior to being passed on this function.
+   *
+   * Deletes the uri 'memo' param if set as 'undefined'.
+   *
+   * @param {string | undefined} memo the uri 'memo' param to be set.
+   */
   set memo(memo: string | undefined) {
     this.setParam("memo", memo);
   }
 
+  /**
+   * Gets the type of the memo.
+   *
+   * @returns {MemoType | undefined} the 'memo_type' uri param if present.
+   */
   get memoType(): MemoType | undefined {
     return this.getParam("memo_type") as MemoType | undefined;
   }
 
+  /**
+   * Sets the type of the memo.
+   *
+   * Deletes the uri 'memo_type' param if set as 'undefined'.
+   *
+   * @param {MemoType | undefined} memoType the uri 'memo_type' param to be set.
+   */
   set memoType(memoType: MemoType | undefined) {
     this.setParam("memo_type", memoType);
-  }
-
-  clone(): Sep7Pay {
-    return new Sep7Pay(this.uri);
   }
 }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Pay.ts
@@ -1,0 +1,83 @@
+import { MemoType } from "@stellar/stellar-sdk";
+import { Sep7Base } from "../Uri";
+import { WEB_STELLAR_PAY_SCHEME } from "../Types";
+
+/**
+ *
+ */
+export class Sep7Pay extends Sep7Base {
+  /**
+   * Creates a Sep7Pay instance with given destination.
+   *
+   * @param {string} destination a valid stellar address to receive the payment.
+   *
+   * @returns {Sep7Pay} the Sep7Pay instance.
+   */
+  static forDestination(destination: string): Sep7Pay {
+    const uri = new Sep7Pay();
+    uri.destination = destination;
+    return uri;
+  }
+
+  /**
+   * Creates a new instance of the Sep7Pay class.
+   *
+   * @constructor
+   * @param {URL | string} uri - uri to initialize the Sep7 instance.
+   */
+  constructor(uri?: URL | string) {
+    super(uri ?? new URL(WEB_STELLAR_PAY_SCHEME));
+  }
+
+  get destination(): string | undefined {
+    return this.getParam("destination");
+  }
+
+  set destination(destination: string | undefined) {
+    this.setParam("destination", destination);
+  }
+
+  get amount(): string | undefined {
+    return this.getParam("amount");
+  }
+
+  set amount(amount: string | undefined) {
+    this.setParam("amount", amount);
+  }
+
+  get assetCode(): string | undefined {
+    return this.getParam("asset_code");
+  }
+
+  set assetCode(assetCode: string | undefined) {
+    this.setParam("asset_code", assetCode);
+  }
+
+  get assetIssuer(): string | undefined {
+    return this.getParam("asset_issuer");
+  }
+
+  set assetIssuer(assetIssuer: string | undefined) {
+    this.setParam("asset_issuer", assetIssuer);
+  }
+
+  get memo(): string | undefined {
+    return this.getParam("memo");
+  }
+
+  set memo(memo: string | undefined) {
+    this.setParam("memo", memo);
+  }
+
+  get memoType(): MemoType | undefined {
+    return this.getParam("memo_type") as MemoType | undefined;
+  }
+
+  set memoType(memoType: MemoType | undefined) {
+    this.setParam("memo_type", memoType);
+  }
+
+  clone(): Sep7Pay {
+    return new Sep7Pay(this.uri);
+  }
+}

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
@@ -7,14 +7,20 @@ import {
 import { Sep7Replacement, WEB_STELLAR_TX_SCHEME } from "../Types";
 
 /**
+ * The Sep-7 'tx' operation represents a request to sign
+ * a specific XDR TransactionEnvelope.
  *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-tx
  */
 export class Sep7Tx extends Sep7Base {
   /**
    * Creates a Sep7Tx instance with given transaction.
    *
-   * @param {Transaction} transaction a transaction which will be used to set uri's xdr
-   * and network_passphrase query params.
+   * Sets the 'xdr' param as a Stellar TransactionEnvelope in XDR format that
+   * is base64 encoded and then URL-encoded.
+   *
+   * @param {Transaction} transaction a transaction which will be used to set the
+   * URI 'xdr' and 'network_passphrase' query params.
    *
    * @returns {Sep7Tx} the Sep7Tx instance.
    */
@@ -35,34 +41,114 @@ export class Sep7Tx extends Sep7Base {
     super(uri ?? new URL(WEB_STELLAR_TX_SCHEME));
   }
 
+  /**
+   * Returns a deep clone of this instance.
+   *
+   * @returns {Sep7Tx} a deep clone of this Sep7Tx instance.
+   */
+  clone(): Sep7Tx {
+    return new Sep7Tx(this.uri);
+  }
+
+  /**
+   * Returns a URL-decoded version of the uri 'xdr' param.
+   *
+   * @returns {string | undefined} URL-decoded 'xdr' param if present.
+   */
   get xdr(): string | undefined {
     return this.getParam("xdr");
   }
 
+  /**
+   * Sets and URL-encodes the uri 'xdr' param.
+   *
+   * Deletes the uri 'xdr' param if set as 'undefined'.
+   *
+   * @param {string | undefined} xdr the uri 'xdr' param to be set.
+   */
   set xdr(xdr: string | undefined) {
     this.setParam("xdr", xdr);
   }
 
+  /**
+   * Returns the uri 'pubkey' param.
+   *
+   * This param specifies which public key the URI handler should sign for.
+   *
+   * @returns {string | undefined} URL-decoded 'pubkey' param if present.
+   */
   get pubkey(): string | undefined {
     return this.getParam("pubkey");
   }
 
+  /**
+   * Sets the uri 'pubkey' param.
+   *
+   * Deletes the uri 'pubkey' param if set as 'undefined'.
+   *
+   * This param should specify which public key you want the URI handler
+   * to sign for.
+   *
+   * @param {string | undefined} pubkey the uri 'pubkey' param to be set.
+   */
   set pubkey(pubkey: string | undefined) {
     this.setParam("pubkey", pubkey);
   }
 
+  /**
+   * Returns a URL-decoded version of the uri 'chain' param.
+   *
+   * There can be an optional chain query param to include a single SEP-0007
+   * request that spawned or triggered the creation of this SEP-0007 request.
+   * This will be a URL-encoded value. The goal of this field is to be
+   * informational only and can be used to forward SEP-0007 requests.
+   *
+   * @returns {string | undefined} URL-decoded 'chain' param if present.
+   */
   get chain(): string | undefined {
     return this.getParam("chain");
   }
 
+  /**
+   * Sets and URL-encodes the uri 'chain' param.
+   *
+   * Deletes the uri 'chain' param if set as 'undefined'.
+   *
+   * There can be an optional chain query param to include a single SEP-0007
+   * request that spawned or triggered the creation of this SEP-0007 request.
+   * This will be a URL-encoded value. The goal of this field is to be
+   * informational only and can be used to forward SEP-0007 requests.
+   *
+   * @param {string | undefined} chain the 'chain' param to be set.
+   */
   set chain(chain: string | undefined) {
     this.setParam("chain", chain);
   }
 
+  /**
+   * Gets a list of fields in the transaction that need to be replaced.
+   *
+   * @returns {Sep7Replacement[]} list of fields that need to be replaced.
+   */
   getReplacements(): Sep7Replacement[] {
     return sep7ReplacementsFromString(this.getParam("replace"));
   }
 
+  /**
+   * Sets and URL-encodes the uri 'replace' param, which is a list of fields in
+   * the transaction that needs to be replaced.
+   *
+   * Deletes the uri 'replace' param if set as empty array '[]' or 'undefined'.
+   *
+   * This 'replace' param should be a URL-encoded value that identifies the
+   * fields to be replaced in the XDR using the 'Txrep (SEP-0011)' representation.
+   * This will be specified in the format of:
+   * txrep_tx_field_name_1:reference_identifier_1,txrep_tx_field_name_2:reference_identifier_2;reference_identifier_1:hint_1,reference_identifier_2:hint_2
+   *
+   * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md
+   *
+   * @param {Sep7Replacement[]} replacements a list of replacements to set.
+   */
   setReplacements(replacements: Sep7Replacement[] | undefined) {
     if (!replacements || replacements.length === 0) {
       this.setParam("replace", undefined);
@@ -71,22 +157,33 @@ export class Sep7Tx extends Sep7Base {
     this.setParam("replace", sep7ReplacementsToString(replacements));
   }
 
+  /**
+   * Adds an additional replacement.
+   *
+   * @param {Sep7Replacement} replacement the replacement to add.
+   */
   addReplacement(replacement: Sep7Replacement) {
     const replacements = this.getReplacements();
     replacements.push(replacement);
     this.setReplacements(replacements);
   }
 
+  /**
+   * Removes all replacements with the given identifier.
+   *
+   * @param {string} id the identifier to remove.
+   */
   removeReplacement(id: string) {
     const replacements = this.getReplacements().filter((r) => r.id !== id);
     this.setReplacements(replacements);
   }
 
+  /**
+   * Creates a Stellar Transaction from the URI's XDR and networkPassphrase.
+   *
+   * @returns {Transaction} the Stellar Transaction.
+   */
   getTransaction(): Transaction {
     return new Transaction(this.xdr, this.networkPassphrase || Networks.PUBLIC);
-  }
-
-  clone(): Sep7Tx {
-    return new Sep7Tx(this.uri);
   }
 }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
@@ -4,7 +4,11 @@ import {
   sep7ReplacementsFromString,
   sep7ReplacementsToString,
 } from "../Uri";
-import { Sep7Replacement, WEB_STELLAR_TX_SCHEME } from "../Types";
+import {
+  Sep7OperationType,
+  Sep7Replacement,
+  WEB_STELLAR_SCHEME,
+} from "../Types";
 
 /**
  * The Sep-7 'tx' operation represents a request to sign
@@ -38,7 +42,7 @@ export class Sep7Tx extends Sep7Base {
    * @param {URL | string} [uri] - uri to initialize the Sep7 instance.
    */
   constructor(uri?: URL | string) {
-    super(uri ?? new URL(WEB_STELLAR_TX_SCHEME));
+    super(uri ?? new URL(`${WEB_STELLAR_SCHEME}${Sep7OperationType.tx}`));
   }
 
   /**

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
@@ -1,0 +1,92 @@
+import { Networks, Transaction } from "@stellar/stellar-sdk";
+import {
+  Sep7Base,
+  sep7ReplacementsFromString,
+  sep7ReplacementsToString,
+} from "../Uri";
+import { Sep7Replacement, WEB_STELLAR_TX_SCHEME } from "../Types";
+
+/**
+ *
+ */
+export class Sep7Tx extends Sep7Base {
+  /**
+   * Creates a Sep7Tx instance with given transaction.
+   *
+   * @param {Transaction} transaction a transaction which will be used to set uri's xdr
+   * and network_passphrase query params.
+   *
+   * @returns {Sep7Tx} the Sep7Tx instance.
+   */
+  static forTransaction(transaction: Transaction): Sep7Tx {
+    const uri = new Sep7Tx();
+    uri.xdr = transaction.toEnvelope().toXDR().toString("base64");
+    uri.networkPassphrase = transaction.networkPassphrase as Networks;
+    return uri;
+  }
+
+  /**
+   * Creates a new instance of the Sep7Tx class.
+   *
+   * @constructor
+   * @param {URL | string} uri - uri to initialize the Sep7 instance.
+   */
+  constructor(uri?: URL | string) {
+    super(uri ?? new URL(WEB_STELLAR_TX_SCHEME));
+  }
+
+  get xdr(): string | undefined {
+    return this.getParam("xdr");
+  }
+
+  set xdr(xdr: string | undefined) {
+    this.setParam("xdr", xdr);
+  }
+
+  get pubkey(): string | undefined {
+    return this.getParam("pubkey");
+  }
+
+  set pubkey(pubkey: string | undefined) {
+    this.setParam("pubkey", pubkey);
+  }
+
+  get chain(): string | undefined {
+    return this.getParam("chain");
+  }
+
+  set chain(chain: string | undefined) {
+    this.setParam("chain", chain);
+  }
+
+  getReplacements(): Sep7Replacement[] {
+    return sep7ReplacementsFromString(this.getParam("replace"));
+  }
+
+  setReplacements(replacements: Sep7Replacement[] | undefined) {
+    if (!replacements || replacements.length === 0) {
+      this.setParam("replace", undefined);
+      return;
+    }
+    this.setParam("replace", sep7ReplacementsToString(replacements));
+  }
+
+  addReplacement(replacement: Sep7Replacement) {
+    const replacements = this.getReplacements();
+    replacements.push(replacement);
+    this.setReplacements(replacements);
+  }
+
+  removeReplacement(id: string) {
+    const replacements = this.getReplacements().filter((r) => r.id !== id);
+    this.setReplacements(replacements);
+  }
+
+  getTransaction(): Transaction {
+    return new Transaction(this.xdr, this.networkPassphrase || Networks.PUBLIC);
+  }
+
+  clone(): Sep7Tx {
+    return new Sep7Tx(this.uri);
+  }
+}

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Tx.ts
@@ -35,7 +35,7 @@ export class Sep7Tx extends Sep7Base {
    * Creates a new instance of the Sep7Tx class.
    *
    * @constructor
-   * @param {URL | string} uri - uri to initialize the Sep7 instance.
+   * @param {URL | string} [uri] - uri to initialize the Sep7 instance.
    */
   constructor(uri?: URL | string) {
     super(uri ?? new URL(WEB_STELLAR_TX_SCHEME));

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/index.ts
@@ -1,0 +1,9 @@
+export { Sep7Base } from "./Sep7Base";
+export { Sep7Pay } from "./Sep7Pay";
+export { Sep7Tx } from "./Sep7Tx";
+export {
+  isValidSep7Uri,
+  parseSep7Uri,
+  sep7ReplacementsFromString,
+  sep7ReplacementsToString,
+} from "./sep7Parser";

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -6,10 +6,20 @@ import {
   Sep7OperationType,
 } from "../Types";
 import {
-  InvalidSep7UriError,
+  Sep7InvalidUriError,
   Sep7UriTypeNotSupportedError,
 } from "../Exceptions";
 
+/**
+ * Returns true if the given URI is a SEP-7 compliant URI, false otherwise.
+ *
+ * Currently this checks whether it starts with 'web+stellar:tx' or 'web+stellar:pay'
+ * and has its required parameters: 'xdr=' and 'destination=' respectively.
+ *
+ * @param {string} uri The URI string to check.
+ *
+ * @returns {boolen} returns `true` if it's a valid Sep-7 uri, `false` otherwise.
+ */
 export const isValidSep7Uri = (uri: string): boolean => {
   // 'xdr' param is required for 'web+stellar:tx' uri
   if (uri.startsWith(WEB_STELLAR_TX_SCHEME) && uri.indexOf("xdr=") !== -1) {
@@ -27,9 +37,21 @@ export const isValidSep7Uri = (uri: string): boolean => {
   return false;
 };
 
+/**
+ * Try parsing a SEP-7 URI string and returns a Sep7Tx or Sep7Pay instance,
+ * depending on the type.
+ *
+ * @param {string} uri The URI string to parse.
+ *
+ * @returns {Sep7Tx | Sep7Pay} a uri parsed Sep7Tx or Sep7Pay instance.
+ *
+ * @throws {Sep7InvalidUriError} if the inputted uri is not a valid SEP-7 URI.
+ * @throws {Sep7UriTypeNotSupportedError} if the inputted uri does not have a
+ * supported SEP-7 type.
+ */
 export const parseSep7Uri = (uri: string): Sep7Tx | Sep7Pay => {
   if (!isValidSep7Uri(uri)) {
-    throw new InvalidSep7UriError();
+    throw new Sep7InvalidUriError();
   }
 
   const url = new URL(uri);
@@ -45,10 +67,28 @@ export const parseSep7Uri = (uri: string): Sep7Tx | Sep7Pay => {
   }
 };
 
+/**
+ * String delimiters shared by the parsing functions below.
+ */
 const HINT_DELIMITER = ";";
 const ID_DELIMITER = ":";
 const LIST_DELIMITER = ",";
 
+/**
+ * Takes a Sep-7 URL-decoded 'replace' string param and parses it to a list of
+ * Sep7Replacement objects for easy of use.
+ *
+ * This string identifies the fields to be replaced in the XDR using
+ * the 'Txrep (SEP-0011)' representation, which should be specified in the format of:
+ * txrep_tx_field_name_1:reference_identifier_1,txrep_tx_field_name_2:reference_identifier_2;reference_identifier_1:hint_1,reference_identifier_2:hint_2
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md
+ *
+ * @param {string} [replacements] a replacements string in the
+ * 'Txrep (SEP-0011)' representation.
+ *
+ * @returns {Sep7Replacement[]} a list of parsed Sep7Replacement objects.
+ */
 export const sep7ReplacementsFromString = (
   replacements?: string,
 ): Sep7Replacement[] => {
@@ -74,6 +114,21 @@ export const sep7ReplacementsFromString = (
   return replacementsList;
 };
 
+/**
+ * Takes a list of Sep7Replacement objects and parses it to a string that
+ * could be URL-encoded and used as a Sep-7 URI 'replace' param.
+ *
+ * This string identifies the fields to be replaced in the XDR using
+ * the 'Txrep (SEP-0011)' representation, which should be specified in the format of:
+ * txrep_tx_field_name_1:reference_identifier_1,txrep_tx_field_name_2:reference_identifier_2;reference_identifier_1:hint_1,reference_identifier_2:hint_2
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0011.md
+ *
+ * @param {Sep7Replacement[]} [replacements] a list of Sep7Replacement objects.
+ *
+ * @returns {string} a string that identifies the fields to be replaced in the
+ * XDR using the 'Txrep (SEP-0011)' representation.
+ */
 export const sep7ReplacementsToString = (
   replacements?: Sep7Replacement[],
 ): string => {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -86,7 +86,8 @@ export const isValidSep7Uri = (uri: string): IsValidSep7UriResult => {
     if (!isValidStellarAddress) {
       return {
         result: false,
-        reason: `the provided 'destination' parameter is not a valid Stellar address`,
+        reason:
+          "the provided 'destination' parameter is not a valid Stellar address",
       };
     }
   }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -1,0 +1,99 @@
+import { Sep7Pay, Sep7Tx } from "../Uri";
+import {
+  Sep7Replacement,
+  WEB_STELLAR_TX_SCHEME,
+  WEB_STELLAR_PAY_SCHEME,
+  Sep7OperationType,
+} from "../Types";
+import {
+  InvalidSep7UriError,
+  Sep7UriTypeNotSupportedError,
+} from "../Exceptions";
+
+export const isValidSep7Uri = (uri: string): boolean => {
+  // 'xdr' param is required for 'web+stellar:tx' uri
+  if (uri.startsWith(WEB_STELLAR_TX_SCHEME) && uri.indexOf("xdr=") !== -1) {
+    return true;
+  }
+
+  // 'destination' param is required for 'web+stellar:pay' uri
+  if (
+    uri.startsWith(WEB_STELLAR_PAY_SCHEME) &&
+    uri.indexOf("destination=") !== -1
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+export const parseSep7Uri = (uri: string): Sep7Tx | Sep7Pay => {
+  if (!isValidSep7Uri(uri)) {
+    throw new InvalidSep7UriError();
+  }
+
+  const url = new URL(uri);
+
+  const type = url.pathname;
+  switch (type) {
+    case Sep7OperationType.tx:
+      return new Sep7Tx(url);
+    case Sep7OperationType.pay:
+      return new Sep7Pay(url);
+    default:
+      throw new Sep7UriTypeNotSupportedError(type);
+  }
+};
+
+const HINT_DELIMITER = ";";
+const ID_DELIMITER = ":";
+const LIST_DELIMITER = ",";
+
+export const sep7ReplacementsFromString = (
+  replacements?: string,
+): Sep7Replacement[] => {
+  if (!replacements) {
+    return [];
+  }
+
+  const [txrepString, hintsString] = replacements.split(HINT_DELIMITER);
+  const hintsList = hintsString.split(LIST_DELIMITER);
+
+  const hintsMap: { [id: string]: string } = {};
+
+  hintsList
+    .map((item) => item.split(ID_DELIMITER))
+    .forEach(([id, hint]) => (hintsMap[id] = hint));
+
+  const txrepList = txrepString.split(LIST_DELIMITER);
+
+  const replacementsList = txrepList
+    .map((item) => item.split(ID_DELIMITER))
+    .map(([path, id]) => ({ id, path, hint: hintsMap[id] }));
+
+  return replacementsList;
+};
+
+export const sep7ReplacementsToString = (
+  replacements?: Sep7Replacement[],
+): string => {
+  if (!replacements || replacements.length === 0) {
+    return "";
+  }
+
+  const hintsMap: { [id: string]: string } = {};
+
+  const txrepString = replacements
+    .map(({ id, hint, path }) => {
+      hintsMap[id] = hint;
+
+      return `${path}${ID_DELIMITER}${id}`;
+    })
+    .join(LIST_DELIMITER);
+
+  const hintsString = Object.entries(hintsMap)
+    .map(([id, hint]) => `${id}${ID_DELIMITER}${hint}`)
+    .join(LIST_DELIMITER);
+
+  return `${txrepString}${HINT_DELIMITER}${hintsString}`;
+};

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Utils/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./camelToSnakeCase";
+export * from "./extractAxiosErrorData";
+export * from "./getResultCode";
 export * from "./toml";
 export * from "./url";
-export * from "./extractAxiosErrorData";

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Watcher/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Watcher/index.ts
@@ -1,4 +1,6 @@
 import { Anchor } from "../Anchor";
+import { Sep6 } from "../Anchor/Sep6";
+import { Sep24 } from "../Anchor/Sep24";
 import {
   AnchorTransaction,
   TransactionStatus,
@@ -329,7 +331,7 @@ export class Watcher {
       };
     }
 
-    let sepObj;
+    let sepObj: Sep6 | Sep24;
     switch (this.sepType) {
       case WatcherSepType.SEP6:
         sepObj = this.anchor.sep6();

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -516,32 +516,89 @@ describe("Sep7Pay", () => {
 
 describe("sep7Parser", () => {
   it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr='", () => {
-    expect(isValidSep7Uri("web+stellar:tx?xdr=")).toBe(true);
-    expect(isValidSep7Uri("web+stellar:tx")).toBe(false);
-    expect(isValidSep7Uri("web+stellar:")).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+      ).result,
+    ).toBe(true);
+    expect(
+      isValidSep7Uri(
+        "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
+      ).result,
+    ).toBe(true);
+    expect(isValidSep7Uri("web+stellar:tx").result).toBe(false);
+    expect(isValidSep7Uri("web+stellar:").result).toBe(false);
   });
 
   it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:pay?destination='", () => {
-    expect(isValidSep7Uri("web+stellar:pay?destination=")).toBe(true);
-    expect(isValidSep7Uri("web+stellar:pay")).toBe(false);
-    expect(isValidSep7Uri("web+stellar:")).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+      ).result,
+    ).toBe(true);
+    expect(
+      isValidSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+      ).result,
+    ).toBe(true);
+    expect(isValidSep7Uri("web+stellar:pay").result).toBe(false);
+    expect(isValidSep7Uri("web+stellar:").result).toBe(false);
   });
 
   it("isValidSep7Uri(uri) returns false when it does not start with 'web+stellar:'", () => {
-    expect(isValidSep7Uri("not-a-stellar-uri:tx?xdr=")).toBe(false);
-    expect(isValidSep7Uri("not-a-stellar-uri:pay?destination=")).toBe(false);
-    expect(isValidSep7Uri("aaa+stellar:tx?xdr=")).toBe(false);
-    expect(isValidSep7Uri("web+steIIar:pay?destination=")).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "not-a-stellar-uri:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+      ).result,
+    ).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "aaa+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
+      ).result,
+    ).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "web+steIIar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+      ).result,
+    ).toBe(false);
+    expect(
+      isValidSep7Uri(
+        "web+stellarr:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+      ).result,
+    ).toBe(false);
+
+    expect(isValidSep7Uri("not-a-stellar-uri:tx?xdr=").result).toBe(false);
+    expect(isValidSep7Uri("not-a-stellar-uri:pay?destination=").result).toBe(
+      false,
+    );
+    expect(isValidSep7Uri("aaa+stellar:tx?xdr=").result).toBe(false);
+    expect(isValidSep7Uri("web+steIIar:pay?destination=").result).toBe(false);
   });
 
-  it("parseSep7Uri(uri) parses a transaction operation uri", () => {
-    const uri = "web+stellar:tx?xdr=";
-    expect(parseSep7Uri(uri)).toBeInstanceOf(Sep7Tx);
+  it("parseSep7Uri(uri) parses a 'tx' operation uri", () => {
+    expect(
+      parseSep7Uri(
+        "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+      ),
+    ).toBeInstanceOf(Sep7Tx);
+    expect(
+      parseSep7Uri(
+        "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
+      ),
+    ).toBeInstanceOf(Sep7Tx);
   });
 
-  it("parseSep7Uri(uri) parses a pay operation uri", () => {
-    const uri = "web+stellar:pay?destination=";
-    expect(parseSep7Uri(uri)).toBeInstanceOf(Sep7Pay);
+  it("parseSep7Uri(uri) parses a 'pay' operation uri", () => {
+    expect(
+      parseSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+      ),
+    ).toBeInstanceOf(Sep7Pay);
+    expect(
+      parseSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+      ),
+    ).toBeInstanceOf(Sep7Pay);
   });
 
   it("parseSep7Uri(uri) throws an error when it is not a valid stellar uri", () => {

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -1,0 +1,606 @@
+import { Keypair, Networks, StellarToml } from "@stellar/stellar-sdk";
+import {
+  NativeAssetId,
+  Sep7Pay,
+  Sep7Tx,
+  SigningKeypair,
+  Stellar,
+  Wallet,
+  isValidSep7Uri,
+  parseSep7Uri,
+  sep7ReplacementsFromString,
+  sep7ReplacementsToString,
+} from "../src";
+import { Sep7OperationType } from "../src/walletSdk/Types";
+import {
+  InvalidSep7UriError,
+  Sep7LongMsgError,
+} from "../src/walletSdk/Exceptions";
+
+const testKp1 = SigningKeypair.fromSecret(
+  "SBKQDF56C5VY2YQTNQFGY7HM6R3V6QKDUEDXZQUCPQOP2EBZWG2QJ2JL",
+);
+
+const testKp2 = SigningKeypair.fromSecret(
+  "SBIK5MF5QONDTKA5ZPXLI2XTBIAOWQEEOZ3TM76XVBPPJ2EEUUXTCIVZ",
+);
+
+let wal: Wallet;
+let stellar: Stellar;
+
+describe("Sep7Base", () => {
+  it("constructor accepts a string uri", () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&callback=https%3A%2F%2Fexample.com%2Fcallback";
+    const uri = new Sep7Tx(uriStr);
+    expect(uri.operationType).toBe(Sep7OperationType.tx);
+    expect(uri.xdr).toBe("test");
+    expect(uri.callback).toBe("https://example.com/callback");
+    expect(uri.toString()).toBe(uriStr);
+  });
+
+  it("constructor accepts URL uri", () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&callback=https%3A%2F%2Fexample.com%2Fcallback";
+    const url = new URL(uriStr);
+    const uri = new Sep7Tx(url);
+    expect(uri.operationType).toBe(Sep7OperationType.tx);
+    expect(uri.xdr).toBe("test");
+    expect(uri.callback).toBe("https://example.com/callback");
+    expect(uri.toString()).toBe(uriStr);
+
+    // should not hold a reference to the original URL
+    url.searchParams.delete("callback");
+    expect(uri.callback).toBe("https://example.com/callback");
+  });
+
+  it("should default to public network if not set", () => {
+    const uri = new Sep7Tx("web+stellar:tx");
+    expect(uri.networkPassphrase).toBe(Networks.PUBLIC);
+
+    uri.networkPassphrase = Networks.TESTNET;
+    expect(uri.networkPassphrase).toBe(Networks.TESTNET);
+  });
+
+  it("allows setting callback with or without 'url:' prefix", () => {
+    const uri = new Sep7Tx("web+stellar:tx");
+    expect(uri.operationType).toBe(Sep7OperationType.tx);
+    expect(uri.callback).toBe(undefined);
+
+    // should remove "url:" prefix when getting
+    uri.callback = "url:https://example.com/callback";
+    expect(uri.callback).toBe("https://example.com/callback");
+
+    uri.callback = "https://example.com/callback";
+    expect(uri.callback).toBe("https://example.com/callback");
+
+    expect(uri.toString()).toBe(
+      "web+stellar:tx?callback=url%3Ahttps%3A%2F%2Fexample.com%2Fcallback",
+    );
+  });
+
+  it("get/set msg", () => {
+    const uri = new Sep7Tx("web+stellar:tx?msg=test%20message");
+
+    expect(uri.msg).toBe("test message");
+
+    uri.msg = "another message";
+    expect(uri.msg).toBe("another message");
+  });
+
+  it("msg throws error if longer than 300 chars", () => {
+    // Should throw when creating from uri string
+    try {
+      new Sep7Tx(
+        "web+stellar:tx?msg=test%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20message%20test%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20message",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7LongMsgError);
+    }
+
+    const uri = new Sep7Tx("web+stellar:tx?msg=test%20message");
+
+    // Should throw when setting 'msg' with existing uri
+    try {
+      uri.msg =
+        "another long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long long message";
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7LongMsgError);
+    }
+  });
+
+  it("get/set network_passphrase", () => {
+    const uri = new Sep7Tx("web+stellar:tx?msg=test%20message");
+
+    // if not present on the uri it should default to Public network
+    expect(uri.networkPassphrase).toBe(Networks.PUBLIC);
+
+    uri.networkPassphrase = Networks.TESTNET;
+    expect(uri.networkPassphrase).toBe(Networks.TESTNET);
+  });
+
+  it("get/set origin_domain", () => {
+    const uri = new Sep7Tx(
+      "web+stellar:tx?msg=test%20message&origin_domain=someDomain.com",
+    );
+
+    expect(uri.originDomain).toBe("someDomain.com");
+
+    uri.originDomain = "anotherDomain.com";
+    expect(uri.originDomain).toBe("anotherDomain.com");
+  });
+
+  it("addSignature() signs the uri and adds a signature to the end", () => {
+    const uriStr =
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com";
+    const uri = new Sep7Pay(uriStr);
+
+    uri.addSignature(Keypair.fromSecret(testKp1.secretKey));
+
+    const expectedSignature =
+      "juY2Pi1/IubcbIDds2CbnL+Imr7dbpJYMW1nLAesOmyh5v/uTVvJwI06RgCGBtHh5+5DWOhJUlEfOSGXPtqgAA==";
+
+    expect(uri.signature).toBe(expectedSignature);
+    expect(
+      uri
+        .toString()
+        .endsWith(`&signature=${encodeURIComponent(expectedSignature)}`),
+    ).toBe(true);
+  });
+
+  it("verifySignature() returns false when there is no origin_domain and signature", async () => {
+    const uriStr = "web+stellar:tx?xdr=test";
+    const uri = new Sep7Tx(uriStr);
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns false when there is origin domain but no signature", async () => {
+    const uriStr = "web+stellar:tx?xdr=test&origin_domain=someDomain.com";
+    const uri = new Sep7Tx(uriStr);
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns false when there is signature but no origin domain", async () => {
+    const uriStr = "web+stellar:tx?xdr=test&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns false when the stellar.toml fails to resolve", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=someDomain.com&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockRejectedValue(new Error("Not Found"));
+
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns false when the stellar.toml has no URI_REQUEST_SIGNING_KEY field", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=someDomain.com&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    jest.spyOn(StellarToml.Resolver, "resolve").mockResolvedValue({});
+
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns false when the signature is not valid", async () => {
+    const uriStr =
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com?signature=invalid";
+    const uri = new Sep7Pay(uriStr);
+
+    jest.spyOn(StellarToml.Resolver, "resolve").mockResolvedValue({
+      URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+    });
+
+    expect(await uri.verifySignature()).toBe(false);
+  });
+
+  it("verifySignature() returns true when the signature is valid", async () => {
+    const uriStr =
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com&signature=juY2Pi1%2FIubcbIDds2CbnL%2BImr7dbpJYMW1nLAesOmyh5v%2FuTVvJwI06RgCGBtHh5%2B5DWOhJUlEfOSGXPtqgAA%3D%3D";
+    const uri = new Sep7Pay(uriStr);
+
+    jest.spyOn(StellarToml.Resolver, "resolve").mockResolvedValue({
+      URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+    });
+
+    expect(await uri.verifySignature()).toBe(true);
+  });
+});
+
+describe("Sep7Tx", () => {
+  beforeAll(async () => {
+    wal = Wallet.TestNet();
+    stellar = wal.stellar();
+
+    try {
+      await stellar.server.loadAccount(testKp1.publicKey);
+      await stellar.server.loadAccount(testKp2.publicKey);
+    } catch (e) {
+      await stellar.fundTestnetAccount(testKp1.publicKey);
+      await stellar.fundTestnetAccount(testKp2.publicKey);
+    }
+  }, 30000);
+
+  it("forTransaction sets the tx parameter", async () => {
+    const txBuilder = await stellar.transaction({
+      sourceAddress: testKp1,
+      baseFee: 100,
+      timebounds: 0,
+    });
+    txBuilder.transfer(testKp2.publicKey, new NativeAssetId(), "1");
+    const tx = txBuilder.build();
+
+    const xdr = tx.toEnvelope().toXDR().toString("base64");
+
+    const uri = Sep7Tx.forTransaction(tx);
+    expect(uri.operationType).toBe("tx");
+    expect(uri.xdr).toBe(xdr);
+    expect(uri.toString()).toBe(
+      `web+stellar:tx?xdr=${encodeURIComponent(
+        xdr,
+      )}&network_passphrase=Test+SDF+Network+%3B+September+2015`,
+    );
+  });
+
+  it("constructor accepts a string uri", () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&callback=https%3A%2F%2Fexample.com%2Fcallback";
+    const uri = new Sep7Tx(uriStr);
+    expect(uri.operationType).toBe("tx");
+    expect(uri.xdr).toBe("test");
+    expect(uri.callback).toBe("https://example.com/callback");
+    expect(uri.toString()).toBe(uriStr);
+  });
+
+  it("allows adding xdr after construction", () => {
+    const uri = new Sep7Tx();
+    uri.xdr = "test";
+    expect(uri.xdr).toBe("test");
+    expect(uri.toString()).toBe("web+stellar:tx?xdr=test");
+  });
+
+  it("get/set xdr", () => {
+    const uri = new Sep7Tx(
+      "web+stellar:tx?xdr=testA&pubkey=testPubkey&callback=https%3A%2F%2Fexample.com%2Fcallback",
+    );
+
+    expect(uri.xdr).toBe("testA");
+
+    uri.xdr = "testB";
+    expect(uri.xdr).toBe("testB");
+  });
+
+  it("get/set pubkey", () => {
+    const uri = new Sep7Tx(
+      "web+stellar:tx?xdr=test&pubkey=testPubkey&callback=https%3A%2F%2Fexample.com%2Fcallback",
+    );
+
+    expect(uri.pubkey).toBe("testPubkey");
+
+    uri.pubkey = testKp1.publicKey;
+    expect(uri.pubkey).toBe(testKp1.publicKey);
+  });
+
+  it("get/set chain", () => {
+    const uri = new Sep7Tx(
+      "web+stellar:tx?xdr=test&pubkey=testPubkey&callback=https%3A%2F%2Fexample.com%2Fcallback&chain=testChain",
+    );
+
+    expect(uri.chain).toBe("testChain");
+
+    uri.chain =
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com&signature=juY2Pi1%2FIubcbIDds2CbnL%2BImr7dbpJYMW1nLAesOmyh5v%2FuTVvJwI06RgCGBtHh5%2B5DWOhJUlEfOSGXPtqgAA%3D%3D";
+    expect(uri.chain).toBe(
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com&signature=juY2Pi1%2FIubcbIDds2CbnL%2BImr7dbpJYMW1nLAesOmyh5v%2FuTVvJwI06RgCGBtHh5%2B5DWOhJUlEfOSGXPtqgAA%3D%3D",
+    );
+  });
+
+  it("parses replacements", () => {
+    // from doc sample: https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-tx
+    const uri = new Sep7Tx(
+      "web+stellar:tx?replace=sourceAccount%3AX%2Coperations%5B0%5D.sourceAccount%3AY%2Coperations%5B1%5D.destination%3AY%3BX%3Aaccount%20from%20where%20you%20want%20to%20pay%20fees%2CY%3Aaccount%20that%20needs%20the%20trustline%20and%20which%20will%20receive%20the%20new%20tokens",
+    );
+
+    const replacements = uri.getReplacements();
+
+    expect(replacements.length).toBe(3);
+
+    expect(replacements[0].id).toBe("X");
+    expect(replacements[0].path).toBe("sourceAccount");
+    expect(replacements[0].hint).toBe(
+      "account from where you want to pay fees",
+    );
+
+    expect(replacements[1].id).toBe("Y");
+    expect(replacements[1].path).toBe("operations[0].sourceAccount");
+    expect(replacements[1].hint).toBe(
+      "account that needs the trustline and which will receive the new tokens",
+    );
+
+    expect(replacements[2].id).toBe("Y");
+    expect(replacements[2].path).toBe("operations[1].destination");
+    expect(replacements[2].hint).toBe(
+      "account that needs the trustline and which will receive the new tokens",
+    );
+  });
+
+  it("addReplacement", () => {
+    const uri = new Sep7Tx("web+stellar:tx");
+    uri.addReplacement({
+      id: "X",
+      path: "sourceAccount",
+      hint: "account from where you want to pay fees",
+    });
+
+    uri.addReplacement({
+      id: "Y",
+      path: "operations[0].sourceAccount",
+      hint: "account that needs the trustline and which will receive the new tokens",
+    });
+
+    uri.addReplacement({
+      id: "Y",
+      path: "operations[1].destination",
+      hint: "account that needs the trustline and which will receive the new tokens",
+    });
+
+    expect(uri.toString()).toBe(
+      "web+stellar:tx?replace=sourceAccount%3AX%2Coperations%5B0%5D.sourceAccount%3AY%2Coperations%5B1%5D.destination%3AY%3BX%3Aaccount+from+where+you+want+to+pay+fees%2CY%3Aaccount+that+needs+the+trustline+and+which+will+receive+the+new+tokens",
+    );
+  });
+
+  it("addReplacement with forTransaction", async () => {
+    const txBuilder = await stellar.transaction({
+      sourceAddress: testKp1,
+      baseFee: 100,
+      timebounds: 0,
+    });
+    txBuilder.transfer(testKp2.publicKey, new NativeAssetId(), "1");
+    const tx = txBuilder.build();
+
+    const xdr = tx.toEnvelope().toXDR().toString("base64");
+
+    const uri = Sep7Tx.forTransaction(tx);
+
+    uri.addReplacement({
+      id: "SRC",
+      path: "sourceAccount",
+      hint: "source account",
+    });
+    uri.addReplacement({ id: "SEQ", path: "seqNum", hint: "sequence number" });
+    uri.addReplacement({ id: "FEE", path: "fee", hint: "fee" });
+
+    expect(uri.toString()).toBe(
+      `web+stellar:tx?xdr=${encodeURIComponent(
+        xdr,
+      )}&network_passphrase=Test+SDF+Network+%3B+September+2015&replace=sourceAccount%3ASRC%2CseqNum%3ASEQ%2Cfee%3AFEE%3BSRC%3Asource+account%2CSEQ%3Asequence+number%2CFEE%3Afee`,
+    );
+  });
+
+  it("setReplacements", () => {
+    const uri = new Sep7Tx("web+stellar:tx");
+    uri.setReplacements([
+      {
+        id: "X",
+        path: "sourceAccount",
+        hint: "account from where you want to pay fees",
+      },
+      {
+        id: "Y",
+        path: "operations[0].sourceAccount",
+        hint: "account that needs the trustline and which will receive the new tokens",
+      },
+      {
+        id: "Y",
+        path: "operations[1].destination",
+        hint: "account that needs the trustline and which will receive the new tokens",
+      },
+    ]);
+
+    expect(uri.toString()).toBe(
+      "web+stellar:tx?replace=sourceAccount%3AX%2Coperations%5B0%5D.sourceAccount%3AY%2Coperations%5B1%5D.destination%3AY%3BX%3Aaccount+from+where+you+want+to+pay+fees%2CY%3Aaccount+that+needs+the+trustline+and+which+will+receive+the+new+tokens",
+    );
+  });
+
+  it("removeReplacement", () => {
+    const uri = new Sep7Tx(
+      "web+stellar:tx?replace=sourceAccount%3AX%2Coperations%5B0%5D.sourceAccount%3AY%2Coperations%5B1%5D.destination%3AY%3BX%3Aaccount%20from%20where%20you%20want%20to%20pay%20fees%2CY%3Aaccount%20that%20needs%20the%20trustline%20and%20which%20will%20receive%20the%20new%20tokens",
+    );
+    uri.removeReplacement("Y");
+
+    expect(uri.getReplacements().length).toBe(1);
+    expect(uri.toString()).toBe(
+      "web+stellar:tx?replace=sourceAccount%3AX%3BX%3Aaccount+from+where+you+want+to+pay+fees",
+    );
+  });
+
+  it("geTransaction", async () => {
+    const txBuilder = await stellar.transaction({
+      sourceAddress: testKp1,
+      baseFee: 100,
+      timebounds: 0,
+    });
+    txBuilder.transfer(testKp2.publicKey, new NativeAssetId(), "1");
+    const tx = txBuilder.build();
+
+    const xdr = tx.toEnvelope().toXDR().toString("base64");
+
+    const uri = new Sep7Tx(`web+stellar:tx?xdr=${encodeURIComponent(xdr)}`);
+
+    expect(uri.getTransaction().toEnvelope().toXDR().toString("base64")).toBe(
+      xdr,
+    );
+  });
+});
+
+describe("Sep7Pay", () => {
+  it("forDestination sets the destination parameter", () => {
+    const uri = Sep7Pay.forDestination(testKp2.publicKey);
+
+    expect(uri.operationType).toBe("pay");
+    expect(uri.destination).toBe(testKp2.publicKey);
+    expect(uri.toString()).toBe(
+      `web+stellar:pay?destination=${testKp2.publicKey}`,
+    );
+  });
+
+  it("get/set destination", () => {
+    const uri = new Sep7Pay(`web+stellar:pay?destination=${testKp2.publicKey}`);
+
+    expect(uri.destination).toBe(testKp2.publicKey);
+
+    uri.destination = "other";
+    expect(uri.destination).toBe("other");
+  });
+
+  it("get/set amount", () => {
+    const uri = new Sep7Pay(
+      `web+stellar:pay?destination=${testKp2.publicKey}&amount=12.3`,
+    );
+
+    expect(uri.amount).toBe("12.3");
+
+    uri.amount = "4";
+    expect(uri.amount).toBe("4");
+  });
+
+  it("get/set assetCode", () => {
+    const uri = new Sep7Pay(
+      `web+stellar:pay?destination=${testKp2.publicKey}&asset_code=USDC`,
+    );
+
+    expect(uri.assetCode).toBe("USDC");
+
+    uri.assetCode = "BRLT";
+    expect(uri.assetCode).toBe("BRLT");
+  });
+
+  it("get/set assetIssuer", () => {
+    const uri = new Sep7Pay(
+      `web+stellar:pay?destination=${testKp2.publicKey}&asset_issuer=issuerA`,
+    );
+
+    expect(uri.assetIssuer).toBe("issuerA");
+    uri.assetIssuer = "issuerB";
+    expect(uri.assetIssuer).toBe("issuerB");
+  });
+
+  it("get/set memo", () => {
+    const uri = new Sep7Pay(
+      `web+stellar:pay?destination=${testKp2.publicKey}&memo=hello+world`,
+    );
+
+    expect(uri.memo).toBe("hello world");
+
+    uri.memo = "bye bye world";
+    expect(uri.memo).toBe("bye bye world");
+  });
+
+  it("get/set memoType", () => {
+    const uri = new Sep7Pay(
+      `web+stellar:pay?destination=${testKp2.publicKey}&memo_type=text`,
+    );
+
+    expect(uri.memoType).toBe("text");
+
+    uri.memoType = "id";
+    expect(uri.memoType).toBe("id");
+  });
+});
+
+describe("sep7Parser", () => {
+  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr='", () => {
+    expect(isValidSep7Uri("web+stellar:tx?xdr=")).toBe(true);
+    expect(isValidSep7Uri("web+stellar:tx")).toBe(false);
+    expect(isValidSep7Uri("web+stellar:")).toBe(false);
+  });
+
+  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:pay?destination='", () => {
+    expect(isValidSep7Uri("web+stellar:pay?destination=")).toBe(true);
+    expect(isValidSep7Uri("web+stellar:pay")).toBe(false);
+    expect(isValidSep7Uri("web+stellar:")).toBe(false);
+  });
+
+  it("isValidSep7Uri(uri) returns false when it does not start with 'web+stellar:'", () => {
+    expect(isValidSep7Uri("not-a-stellar-uri:tx?xdr=")).toBe(false);
+    expect(isValidSep7Uri("not-a-stellar-uri:pay?destination=")).toBe(false);
+    expect(isValidSep7Uri("aaa+stellar:tx?xdr=")).toBe(false);
+    expect(isValidSep7Uri("web+steIIar:pay?destination=")).toBe(false);
+  });
+
+  it("parseSep7Uri(uri) parses a transaction operation uri", () => {
+    const uri = "web+stellar:tx?xdr=";
+    expect(parseSep7Uri(uri)).toBeInstanceOf(Sep7Tx);
+  });
+
+  it("parseSep7Uri(uri) parses a pay operation uri", () => {
+    const uri = "web+stellar:pay?destination=";
+    expect(parseSep7Uri(uri)).toBeInstanceOf(Sep7Pay);
+  });
+
+  it("parseSep7Uri(uri) throws an error when it is not a valid stellar uri", () => {
+    const uri = "not-a-stellar-uri:tx";
+
+    try {
+      const sep7Uri = parseSep7Uri(uri);
+      expect(sep7Uri).toBeUndefined();
+    } catch (error) {
+      expect(error).toBeInstanceOf(InvalidSep7UriError);
+    }
+  });
+
+  it("sep7ReplacementsFromString() parses it successfully", () => {
+    const str =
+      "sourceAccount:X,operations[0].sourceAccount:Y,operations[1].destination:Y;X:account from where you want to pay fees,Y:account that needs the trustline and which will receive the new tokens";
+    const replacements = sep7ReplacementsFromString(str);
+
+    expect(replacements[0].id).toBe("X");
+    expect(replacements[0].path).toBe("sourceAccount");
+    expect(replacements[0].hint).toBe(
+      "account from where you want to pay fees",
+    );
+
+    expect(replacements[1].id).toBe("Y");
+    expect(replacements[1].path).toBe("operations[0].sourceAccount");
+    expect(replacements[1].hint).toBe(
+      "account that needs the trustline and which will receive the new tokens",
+    );
+
+    expect(replacements[2].id).toBe("Y");
+    expect(replacements[2].path).toBe("operations[1].destination");
+    expect(replacements[2].hint).toBe(
+      "account that needs the trustline and which will receive the new tokens",
+    );
+  });
+
+  it("sep7ReplacementsToString outputs the right string", () => {
+    const expected =
+      "sourceAccount:X,operations[0].sourceAccount:Y,operations[1].destination:Y;X:account from where you want to pay fees,Y:account that needs the trustline and which will receive the new tokens";
+    const replacements = [
+      {
+        id: "X",
+        path: "sourceAccount",
+        hint: "account from where you want to pay fees",
+      },
+      {
+        id: "Y",
+        path: "operations[0].sourceAccount",
+        hint: "account that needs the trustline and which will receive the new tokens",
+      },
+      {
+        id: "Y",
+        path: "operations[1].destination",
+        hint: "account that needs the trustline and which will receive the new tokens",
+      },
+    ];
+
+    const actual = sep7ReplacementsToString(replacements);
+    expect(actual).toBe(expected);
+  });
+});

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -25,6 +25,18 @@ const testKp2 = SigningKeypair.fromSecret(
   "SBIK5MF5QONDTKA5ZPXLI2XTBIAOWQEEOZ3TM76XVBPPJ2EEUUXTCIVZ",
 );
 
+const xdrs = {
+  classic: encodeURIComponent(
+    "AAAAAgAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAGQABqQMAAAAAQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAACCMXQVfkjpO2gAJQzKsUsPfdBCyfrvy7sr8+35cOxOSwAAAAAAmJaAAAAAAAAAAAFw7E5LAAAAQBu4V+/lttEONNM6KFwdSf5TEEogyEBy0jTOHJKuUzKScpLHyvDJGY+xH9Ri4cIuA7AaB8aL+VdlucCfsNYpKAY=",
+  ),
+  sorobanTransfer: encodeURIComponent(
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucaFsAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAIdHJhbnNmZXIAAAADAAAAEgAAAAAAAAAAjOiEfRh4kaFVQDu/CSTZLMtnyg0DbNowZ/G2nLES3KwAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAACHRyYW5zZmVyAAAAAwAAABIAAAAAAAAAAIzohH0YeJGhVUA7vwkk2SzLZ8oNA2zaMGfxtpyxEtysAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAACAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrAAAAAEAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAEAAAAAEAAAACAAAADwAAAAdCYWxhbmNlAAAAABIAAAAAAAAAAOgWXYAJP0dmRsJ65pP0wAh1K2l1/nzAzc/bieXvfwCdAAAAAQBkcwsAACBwAAABKAAAAAAAAB1kAAAAAA==",
+  ),
+  sorobanMint: encodeURIComponent(
+    "AAAAAgAAAACM6IR9GHiRoVVAO78JJNksy2fKDQNs2jBn8bacsRLcrDucQIQAAAWIAAAAMQAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAGAAAAAAAAAABHkEVdJ+UfDnWpBr/qF582IEoDQ0iW0WPzO9CEUdvvh8AAAAEbWludAAAAAIAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAoAAAAAAAAAAAAAAAAAAAAFAAAAAQAAAAAAAAAAAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAABG1pbnQAAAACAAAAEgAAAAAAAAAA6BZdgAk/R2ZGwnrmk/TACHUraXX+fMDNz9uJ5e9/AJ0AAAAKAAAAAAAAAAAAAAAAAAAABQAAAAAAAAABAAAAAAAAAAIAAAAGAAAAAR5BFXSflHw51qQa/6hefNiBKA0NIltFj8zvQhFHb74fAAAAFAAAAAEAAAAHa35L+/RxV6EuJOVk78H5rCN+eubXBWtsKrRxeLnnpRAAAAABAAAABgAAAAEeQRV0n5R8OdakGv+oXnzYgSgNDSJbRY/M70IRR2++HwAAABAAAAABAAAAAgAAAA8AAAAHQmFsYW5jZQAAAAASAAAAAAAAAADoFl2ACT9HZkbCeuaT9MAIdStpdf58wM3P24nl738AnQAAAAEAYpBIAAAfrAAAAJQAAAAAAAAdYwAAAAA=",
+  ),
+};
+
 let wal: Wallet;
 let stellar: Stellar;
 
@@ -515,22 +527,39 @@ describe("Sep7Pay", () => {
 });
 
 describe("sep7Parser", () => {
-  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr='", () => {
+  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr=<valid-xdr-envelope>'", () => {
     expect(
       isValidSep7Uri(
         "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
       ).result,
     ).toBe(true);
+
     expect(
       isValidSep7Uri(
         "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
       ).result,
     ).toBe(true);
-    expect(isValidSep7Uri("web+stellar:tx").result).toBe(false);
-    expect(isValidSep7Uri("web+stellar:").result).toBe(false);
+
+    expect(
+      isValidSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.classic}&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+      ).result,
+    ).toBe(true);
+
+    expect(
+      isValidSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.sorobanTransfer}&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+      ).result,
+    ).toBe(true);
+
+    expect(
+      isValidSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.sorobanMint}&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+      ).result,
+    ).toBe(true);
   });
 
-  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:pay?destination='", () => {
+  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:pay?destination=<valid-stellar-address>'", () => {
     expect(
       isValidSep7Uri(
         "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
@@ -541,41 +570,101 @@ describe("sep7Parser", () => {
         "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
       ).result,
     ).toBe(true);
-    expect(isValidSep7Uri("web+stellar:pay").result).toBe(false);
-    expect(isValidSep7Uri("web+stellar:").result).toBe(false);
+
+    // With Muxed destination
+    expect(
+      isValidSep7Uri(
+        "web+stellar:pay?destination=MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+      ).result,
+    ).toBe(true);
+
+    // With Soroban Contract destination
+    // TODO: add support for this once "@stellar/stellar-sdk"
+    // package is updated to version >= "v12.0.1".
+    // expect(
+    //   isValidSep7Uri(
+    //     "web+stellar:pay?destination=CAPECFLUT6KHYOOWUQNP7KC6PTMICKANBURFWRMPZTXUEEKHN67B7UI2&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+    //   ).result,
+    // ).toBe(true);
   });
 
-  it("isValidSep7Uri(uri) returns false when it does not start with 'web+stellar:'", () => {
-    expect(
-      isValidSep7Uri(
-        "not-a-stellar-uri:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
-      ).result,
-    ).toBe(false);
-    expect(
-      isValidSep7Uri(
-        "aaa+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
-      ).result,
-    ).toBe(false);
-    expect(
-      isValidSep7Uri(
-        "web+steIIar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
-      ).result,
-    ).toBe(false);
-    expect(
-      isValidSep7Uri(
-        "web+stellarr:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
-      ).result,
-    ).toBe(false);
-
-    expect(isValidSep7Uri("not-a-stellar-uri:tx?xdr=").result).toBe(false);
-    expect(isValidSep7Uri("not-a-stellar-uri:pay?destination=").result).toBe(
-      false,
+  it("isValidSep7Uri(uri) returns 'false' with 'reason' when it is not valid in some way", () => {
+    const validation1 = isValidSep7Uri(
+      "not-a-stellar-uri:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
     );
-    expect(isValidSep7Uri("aaa+stellar:tx?xdr=").result).toBe(false);
-    expect(isValidSep7Uri("web+steIIar:pay?destination=").result).toBe(false);
+    expect(validation1.result).toBe(false);
+    expect(validation1.reason).toBe("it must start with 'web+stellar:'");
+
+    const validation2 = isValidSep7Uri(
+      "web+steIIar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+    );
+    expect(validation2.result).toBe(false);
+    expect(validation2.reason).toBe("it must start with 'web+stellar:'");
+
+    const validation3 = isValidSep7Uri(
+      "web-stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+    );
+    expect(validation3.result).toBe(false);
+    expect(validation3.reason).toBe("it must start with 'web+stellar:'");
+
+    const validation4 = isValidSep7Uri(
+      "web+stellar:send?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+    );
+    expect(validation4.result).toBe(false);
+    expect(validation4.reason).toBe(
+      "operation type 'send' is not currently supported",
+    );
+
+    const validation5 = isValidSep7Uri(
+      "web+stellar:pay?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+    );
+    expect(validation5.result).toBe(false);
+    expect(validation5.reason).toBe(
+      "operation type 'pay' must have a 'destination' parameter",
+    );
+
+    const validation6 = isValidSep7Uri(
+      "web+stellar:tx?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
+    );
+    expect(validation6.result).toBe(false);
+    expect(validation6.reason).toBe(
+      "operation type 'tx' must have a 'xdr' parameter",
+    );
+
+    const validation7 = isValidSep7Uri(
+      "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
+    );
+    expect(validation7.result).toBe(false);
+    expect(validation7.reason).toBe(
+      "the provided 'xdr' parameter is not a valid transaction envelope on the 'Public Global Stellar Network ; September 2015' network",
+    );
+
+    const validation8 = isValidSep7Uri(
+      `web+stellar:tx?network_passphrase=${Networks.TESTNET}&xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+    );
+    expect(validation8.result).toBe(false);
+    expect(validation8.reason).toBe(
+      "the provided 'xdr' parameter is not a valid transaction envelope on the 'Test SDF Network ; September 2015' network",
+    );
+
+    const validation9 = isValidSep7Uri(
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMST6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+    );
+    expect(validation9.result).toBe(false);
+    expect(validation9.reason).toBe(
+      "the provided 'destination' parameter is not a valid Stellar address",
+    );
+
+    const validation10 = isValidSep7Uri(
+      `web+stellar:tx?xdr=${xdrs.classic}&msg=long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20message&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+    );
+    expect(validation10.result).toBe(false);
+    expect(validation10.reason).toBe(
+      "the 'msg' parameter should be no longer than 300 characters",
+    );
   });
 
-  it("parseSep7Uri(uri) parses a 'tx' operation uri", () => {
+  it("parseSep7Uri(uri) parses a valid 'tx' operation uri", () => {
     expect(
       parseSep7Uri(
         "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
@@ -586,9 +675,24 @@ describe("sep7Parser", () => {
         "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
       ),
     ).toBeInstanceOf(Sep7Tx);
+    expect(
+      parseSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.classic}&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024`,
+      ),
+    ).toBeInstanceOf(Sep7Tx);
+    expect(
+      parseSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.sorobanMint}&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024`,
+      ),
+    ).toBeInstanceOf(Sep7Tx);
+    expect(
+      parseSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.sorobanTransfer}&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024`,
+      ),
+    ).toBeInstanceOf(Sep7Tx);
   });
 
-  it("parseSep7Uri(uri) parses a 'pay' operation uri", () => {
+  it("parseSep7Uri(uri) parses a valid 'pay' operation uri", () => {
     expect(
       parseSep7Uri(
         "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&memo_type=MEMO_TEXT&msg=pay%20me%20with%20lumens",
@@ -599,16 +703,78 @@ describe("sep7Parser", () => {
         "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
       ),
     ).toBeInstanceOf(Sep7Pay);
+
+    // With Muxed destination
+    expect(
+      parseSep7Uri(
+        "web+stellar:pay?destination=MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAABUTGI4&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+      ),
+    ).toBeInstanceOf(Sep7Pay);
+
+    // With Soroban Contract destination
+    // TODO: add support for this once "@stellar/stellar-sdk"
+    // package is updated to version >= "v12.0.1".
+    // expect(
+    //   parseSep7Uri(
+    //     "web+stellar:pay?destination=CAPECFLUT6KHYOOWUQNP7KC6PTMICKANBURFWRMPZTXUEEKHN67B7UI2&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+    //   ),
+    // ).toBeInstanceOf(Sep7Pay);
   });
 
-  it("parseSep7Uri(uri) throws an error when it is not a valid stellar uri", () => {
-    const uri = "not-a-stellar-uri:tx";
-
+  it("parseSep7Uri(uri) throws an error when it is not a valid Stellar uri in some way", () => {
     try {
-      const sep7Uri = parseSep7Uri(uri);
-      expect(sep7Uri).toBeUndefined();
+      parseSep7Uri(
+        "not-a-stellar-uri:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+      );
     } catch (error) {
       expect(error).toBeInstanceOf(Sep7InvalidUriError);
+      expect(error.toString()).toContain(
+        "Invalid Stellar Sep-7 URI, reason: it must start with 'web+stellar:'",
+      );
+    }
+
+    try {
+      parseSep7Uri(
+        "web+stellar:send?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7InvalidUriError);
+      expect(error.toString()).toContain(
+        "Invalid Stellar Sep-7 URI, reason: operation type 'send' is not currently supported",
+      );
+    }
+
+    try {
+      parseSep7Uri(
+        "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7InvalidUriError);
+      expect(error.toString()).toContain(
+        "Invalid Stellar Sep-7 URI, reason: the provided 'xdr' parameter is not a valid transaction envelope on the 'Public Global Stellar Network ; September 2015' network",
+      );
+    }
+
+    try {
+      parseSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMST6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.123&asset_code=USD&asset_issuer=GCRCUE2C5TBNIPYHMEP7NK5RWTT2WBSZ75CMARH7GDOHDDCQH3XANFOB&memo=hasysda987fs&memo_type=MEMO_TEXT&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fhasysda987fs%3Fasset%3DUSD",
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7InvalidUriError);
+      expect(error.toString()).toContain(
+        "Invalid Stellar Sep-7 URI, reason: the provided 'destination' parameter is not a valid Stellar address",
+      );
+    }
+
+    try {
+      parseSep7Uri(
+        `web+stellar:tx?xdr=${xdrs.classic}&msg=long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20long%20message&replace=sourceAccount%3AX%3BX%3Aaccount%20on%20which%20to%20create%20the%20trustline`,
+      );
+    } catch (error) {
+      expect(error).toBeInstanceOf(Sep7InvalidUriError);
+      expect(error.toString()).toContain(
+        "Invalid Stellar Sep-7 URI, reason: the 'msg' parameter should be no longer than 300 characters",
+      );
     }
   });
 

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../src";
 import { Sep7OperationType } from "../src/walletSdk/Types";
 import {
-  InvalidSep7UriError,
+  Sep7InvalidUriError,
   Sep7LongMsgError,
 } from "../src/walletSdk/Exceptions";
 
@@ -551,7 +551,7 @@ describe("sep7Parser", () => {
       const sep7Uri = parseSep7Uri(uri);
       expect(sep7Uri).toBeUndefined();
     } catch (error) {
-      expect(error).toBeInstanceOf(InvalidSep7UriError);
+      expect(error).toBeInstanceOf(Sep7InvalidUriError);
     }
   });
 

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -527,7 +527,7 @@ describe("Sep7Pay", () => {
 });
 
 describe("sep7Parser", () => {
-  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr=<valid-xdr-envelope>'", () => {
+  it("isValidSep7Uri(uri) returns true when it starts with 'web+stellar:tx?xdr=<valid-url-encoded-xdr-envelope>'", () => {
     expect(
       isValidSep7Uri(
         "web+stellar:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",


### PR DESCRIPTION
Ticket: https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?selectedIssue=WAL-1449

This PR adds support for SEP-7 through the following classes:
- `Sep7Base`: abstract base class with common functions and attributes used by both `tx` and `pay` operations
- `Sep7Tx`: implements the [Sep-7 `tx` operation](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-tx)
- `Sep7Pay`: implements the [Sep-7 `pay` operation](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-pay)

This PR also adds some convenient parsing/helper functions as follow:
- `isValidSep7Uri`: checks if uri is Sep-7 compliant, if not returns a explanatory `reason` message
- `parseSep7Uri`: parses a Sep-7 uri to either a Sep7Tx or Sep7Pay instance
- `sep7ReplacementsFromString`: converts a complex replacements string to a list of friendly replacements objects
- `sep7ReplacementsToString`: converts a list of friendly replacements objects to a complex replacements string

Those classes and functions can be used to either `generate` a new Sep-7 URI or `handle` an existing Sep-7 URI.

This PR also adds a bunch of `tests` and `JSDocs` that should cover all new classes and functions.

This PR also adds a few missing types and exceptions from existing code (harmless changes).