### PR TITLE
Fix response objects returned on Customer functions

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
@@ -64,7 +64,7 @@ export class Sep12 {
     if (!resp.data.id) {
       throw new CustomerNotFoundError(params);
     }
-    return resp;
+    return resp.data;
   }
 
   /**
@@ -104,7 +104,7 @@ export class Sep12 {
           : this.headers,
       },
     );
-    return resp;
+    return resp.data;
   }
 
   /**
@@ -154,7 +154,7 @@ export class Sep12 {
           : this.headers,
       },
     );
-    return resp;
+    return resp.data;
   }
 
   /**

--- a/@stellar/typescript-wallet-sdk/test/customer.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/customer.test.ts
@@ -35,18 +35,18 @@ describe("Customer", () => {
         type: customerType,
       },
     });
-    expect(resp.data.id).toBeTruthy();
-    const { id } = resp.data;
+    expect(resp.id).toBeTruthy();
+    const { id } = resp;
 
     // Get
     resp = await sep12.getCustomer({ id, type: customerType });
-    expect(Object.keys(resp.data).sort()).toEqual(
+    expect(Object.keys(resp).sort()).toEqual(
       ["id", "provided_fields", "fields", "status"].sort(),
     );
-    expect(Object.keys(resp.data?.provided_fields).sort()).toEqual(
+    expect(Object.keys(resp?.provided_fields).sort()).toEqual(
       ["first_name", "last_name", "email_address"].sort(),
     );
-    expect(Object.keys(resp.data?.fields).sort()).toEqual(
+    expect(Object.keys(resp?.fields).sort()).toEqual(
       [
         "bank_account_number",
         "bank_number",
@@ -70,11 +70,11 @@ describe("Customer", () => {
       },
       id,
     });
-    expect(resp.data.id).toBeTruthy();
+    expect(resp.id).toBeTruthy();
 
     // Get again, check that the provided fields updated
     resp = await sep12.getCustomer({ id, type: customerType });
-    expect(Object.keys(resp.data.fields).length).toBe(0);
+    expect(Object.keys(resp.fields).length).toBe(0);
 
     // Delete
     await sep12.delete();

--- a/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
@@ -60,7 +60,7 @@ describe("Anchor Platform Integration Tests", () => {
         bank_account_number: "12345",
       },
     });
-    expect(sep12Resp.data.id).toBeTruthy();
+    expect(sep12Resp.id).toBeTruthy();
 
     // SEP-6 deposit
     const sep6 = anchor.sep6();


### PR DESCRIPTION
It turns out that our `Customer` class functions are returning a `raw` request `response` instead of returning its `data` field.

This PR fixes that so it matches the expected return types for those functions as following: 
- `getCustomer` should return object of type `GetCustomerResponse`
- `add` should return object of type `AddCustomerResponse`
- `update` should return object of type `AddCustomerResponse`

All the other class functions on the SDK also follow this same pattern of returning `response.data` field, so let's keep this same pattern for the `Customer` class.

It is important to notice that it is a `BREAKING CHANGE` for wallets out there that are using our existing `Customer` class.

_Note: we need to merge this PR first in order to fix the tests on the [Sep-7 PR](https://github.com/stellar/typescript-wallet-sdk/pull/141)_