### PR TITLE
[Beta build] Bump version to 1.6.0 + Changelogs

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,8 @@
+# Release notes - Typescript Wallet SDK Key Manager - 1.6.0
+
+### Added
+* Upgrade @stellar/stellar-sdk to 12.1.0 (#143)
+
 # Release notes - Typescript Wallet SDK Key Manager - 1.5.0
 
 ### Added

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "node": ">=18"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,4 +1,9 @@
-# Release notes - Typescript Wallet SDK Key Soroban - 1.5.0
+# Release notes - Typescript Wallet SDK Soroban - 1.6.0
+
+### Added
+* Upgrade @stellar/stellar-sdk to 12.1.0 (#143)
+
+# Release notes - Typescript Wallet SDK Soroban - 1.5.0
 
 ### Added
 * Init to the project, added soroban functionality

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "node": ">=18"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,6 +1,16 @@
+# Release notes - Typescript Wallet SDK - 1.6.0
+
+### Added
+* Support for Sep-7 (#141)(#144)
+* Upgrade @stellar/stellar-sdk to 12.1.0 (#143)
+* New on_hold status (#140)
+
+### Fixed
+* [BREAKING CHANGE] Fix response objects returned on Customer functions (#142)
+
 # Release notes - Typescript Wallet SDK - 1.5.0
 
-# Added
+### Added
 * AuthHeaderSigner to Authentication Flow
 * End to end tests for testing browser build 
 * Beta builds on merges to develop branch

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
This PR bumps all package versions to `v1.6.0` and adds the `Changelogs`.

This PR is pointing to `develop` branch, which means once it's merged a `1.6.0-beta.{timestamp}` build of the main package should be [automatically issued](https://github.com/stellar/typescript-wallet-sdk/blob/main/.github/workflows/npmPublishBeta.yml) on npm (see [canary builds task](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?selectedIssue=WAL-1413)).