### PR TITLE
Add registry-url to beta workflow

### DIFF
--- a/.github/workflows/npmPublishBeta.yml
+++ b/.github/workflows/npmPublishBeta.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 18
-
+          registry-url: https://registry.npmjs.org/
       - run: yarn install
       - run: yarn build
       - run: yarn test:ci


### PR DESCRIPTION
Looks like this config is missing compared to the other workflows.

Note: this PR merges it to `main` (as opposite to this [other PR](https://github.com/stellar/typescript-wallet-sdk/pull/147) which was _wrongly_ pointing to `develop`).