### PR TITLE
Replace `tweetnacl-util` with `@stablelib` packages

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -35,6 +35,8 @@
     "@albedo-link/intent": "^0.12.0",
     "@ledgerhq/hw-app-str": "^6.28.4",
     "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
+    "@stablelib/base64": "^2.0.0",
+    "@stablelib/utf8": "^2.0.0",
     "@stellar/freighter-api": "^2.0.0",
     "@stellar/stellar-sdk": "12.1.0",
     "@trezor/connect-plugin-stellar": "^9.0.2",

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -41,8 +41,7 @@
     "bignumber.js": "^9.1.2",
     "scrypt-async": "^2.0.1",
     "trezor-connect": "^8.2.12",
-    "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1"
+    "tweetnacl": "^1.0.3"
   },
   "scripts": {
     "test": "jest --watchAll",

--- a/@stellar/typescript-wallet-sdk/jest.e2e.config.js
+++ b/@stellar/typescript-wallet-sdk/jest.e2e.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   rootDir: "./",
   preset: "ts-jest",
+  transformIgnorePatterns: [`/node_modules/(?!${["@stablelib"].join("|")})`],
   transform: {
     "^.+\\.(ts|tsx)?$": "ts-jest",
     "^.+\\.(js|jsx)$": "babel-jest",

--- a/@stellar/typescript-wallet-sdk/jest.integration.config.js
+++ b/@stellar/typescript-wallet-sdk/jest.integration.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   rootDir: "./",
   preset: "ts-jest",
+  transformIgnorePatterns: [`/node_modules/(?!${["@stablelib"].join("|")})`],
   transform: {
     "^.+\\.(ts|tsx)?$": "ts-jest",
     "^.+\\.(js|jsx)$": "babel-jest",

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -53,7 +53,6 @@
     "query-string": "^7.1.3",
     "stream-http": "^3.2.0",
     "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1",
     "url": "^0.11.0",
     "util": "^0.12.5",
     "utility-types": "^3.10.0",

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -12,6 +12,8 @@
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.23.3",
+    "@stablelib/base64": "^2.0.0",
+    "@stablelib/utf8": "^2.0.0",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
     "@types/jest": "^29.4.0",

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -12,8 +12,6 @@
   "devDependencies": {
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.23.3",
-    "@stablelib/base64": "^2.0.0",
-    "@stablelib/utf8": "^2.0.0",
     "@stellar/prettier-config": "^1.0.1",
     "@stellar/tsconfig": "^1.0.2",
     "@types/jest": "^29.4.0",
@@ -46,6 +44,8 @@
     "webpack-cli": "^5.1.1"
   },
   "dependencies": {
+    "@stablelib/base64": "^2.0.0",
+    "@stablelib/utf8": "^2.0.0",
     "@stellar/stellar-sdk": "12.1.0",
     "axios": "^1.4.0",
     "base64url": "^3.0.1",

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/AuthHeaderSigner.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/AuthHeaderSigner.ts
@@ -1,7 +1,7 @@
 import { AxiosInstance } from "axios";
+import { encode as utf8Encode } from "@stablelib/utf8";
 import { StrKey } from "@stellar/stellar-sdk";
 import nacl from "tweetnacl";
-import naclUtil from "tweetnacl-util";
 import base64url from "base64url";
 
 import { SigningKeypair } from "../Horizon/Account";
@@ -66,12 +66,10 @@ export class DefaultAuthHeaderSigner implements AuthHeaderSigner {
     const encodedPayload = base64url(
       JSON.stringify({ ...claims, exp: timeExp, iat: issuedAt }),
     );
+    const utf8Jwt = utf8Encode(`${encodedHeader}.${encodedPayload}`);
 
     // sign JWT and create signature
-    const signature = nacl.sign.detached(
-      naclUtil.decodeUTF8(`${encodedHeader}.${encodedPayload}`),
-      naclKP.secretKey,
-    );
+    const signature = nacl.sign.detached(utf8Jwt, naclKP.secretKey);
     const encodedSignature = base64url(Buffer.from(signature));
 
     const jwt = `${encodedHeader}.${encodedPayload}.${encodedSignature}`;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 const commonConfigs = {
+  transformIgnorePatterns: [`/node_modules/(?!${["@stablelib"].join("|")})`],
   transform: {
     "^.+\\.(js|jsx|ts|tsx|mjs)$": ["babel-jest"],
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,6 +2521,16 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
   integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
+"@stablelib/base64@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-2.0.0.tgz#f13a98549cd5ca0750cd177bbd08b599d24e5f8e"
+  integrity sha512-ffSfySa1ZpZYzM5FQ2xILQ2jifQ+GlgbDJzRTCtaB0sqta88KYghB/tlSV2VS2iHRCvMdUvJlLOW1rmSkziWnw==
+
+"@stablelib/utf8@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stablelib/utf8/-/utf8-2.0.0.tgz#05725ef9d39ed10a017e1b6e01374bd998c83167"
+  integrity sha512-bHaUduwFKYgj6rRvA5udyyg+ASx6gJZiQaXvfBHb7A2r+X9tRIKJ/VmpQKFQnEMInpBTh7jJLy+Gt99GH9YZ9g==
+
 "@stellar/freighter-api@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@stellar/freighter-api/-/freighter-api-2.0.0.tgz#488915a4aa0cec8c9a3fc84ef31e21cd5ec41343"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7573,11 +7573,6 @@ tslib@^2.5.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
   integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
-tweetnacl-util@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
-  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
-
 tweetnacl@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"


### PR DESCRIPTION
The `tweetnacl-util` package is `crashing` on **React Native**, so let's replace it with `@stablelib` packages which apparently work fine with all envs.

Note that it's even mentioned on the `tweetnacl-util` [npm package description](https://www.npmjs.com/package/tweetnacl-util?activeTab=readme#notice):

_...For example, they **don't work under React Native**._

_Instead of this package, I strongly recommend using my **StableLib** packages:_
_- **@stablelib/utf8** for UTF-8 encoding/decoding ..._
_- **@stablelib/base64** for constant-time Base64 encoding/decoding ..._


