### PR TITLE
Export missing classes and aliases

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/index.ts
@@ -14,14 +14,29 @@ export {
   ApplicationConfiguration,
 } from "./walletSdk";
 export { Anchor } from "./walletSdk/Anchor";
-export { Sep24 } from "./walletSdk/Anchor/Sep24";
-export { IssuedAssetId, NativeAssetId, FiatAssetId } from "./walletSdk/Asset";
-export { Sep10, WalletSigner, DefaultSigner } from "./walletSdk/Auth";
+export { Sep6, Transfer } from "./walletSdk/Anchor/Sep6";
+export { Sep24, Interactive } from "./walletSdk/Anchor/Sep24";
+export { Sep38, Quote } from "./walletSdk/Anchor/Sep38";
+export {
+  StellarAssetId,
+  IssuedAssetId,
+  NativeAssetId,
+  XLM,
+  FiatAssetId,
+} from "./walletSdk/Asset";
+export {
+  Sep10,
+  Auth,
+  WalletSigner,
+  DefaultSigner,
+  DomainSigner,
+} from "./walletSdk/Auth";
 export {
   AuthHeaderSigner,
   DefaultAuthHeaderSigner,
   DomainAuthHeaderSigner,
 } from "./walletSdk/Auth/AuthHeaderSigner";
+export { Sep12, Customer } from "./walletSdk/Customer";
 export {
   AccountKeypair,
   PublicKeypair,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep24.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep24.ts
@@ -31,6 +31,11 @@ type Sep24Params = {
 };
 
 /**
+ * @alias Interactive alias for Sep24 class.
+ */
+export type Interactive = Sep24;
+
+/**
  * Interactive flow for deposit and withdrawal using SEP-24.
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md}
  * Do not create this object directly, use the Anchor class.

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep38.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep38.ts
@@ -21,6 +21,11 @@ import {
 import { camelToSnakeCaseObject } from "../Utils";
 
 /**
+ * @alias Quote alias for Sep38 class.
+ */
+export type Quote = Sep38;
+
+/**
  * Quote service using SEP-38. It can be used for getting price quotes from an anchor
  * for exchanging assets.
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0038.md}

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
@@ -28,6 +28,11 @@ import {
 import { camelToSnakeCaseObject } from "../Utils";
 
 /**
+ * @alias Transfer alias for Sep6 class.
+ */
+export type Transfer = Sep6;
+
+/**
  * Flow for creating deposits and withdrawals with an anchor using SEP-6.
  * For an interactive flow use Sep24 instead.
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md}

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
@@ -2,15 +2,15 @@ import { AxiosInstance } from "axios";
 import { StellarToml } from "@stellar/stellar-sdk";
 
 import { Config } from "../";
-import { Sep10 } from "../Auth";
-import { Sep12 } from "../Customer";
+import { Auth, Sep10 } from "../Auth";
+import { Customer, Sep12 } from "../Customer";
 import {
   ServerRequestFailedError,
   KYCServerNotFoundError,
 } from "../Exceptions";
-import { Sep6 } from "./Sep6";
-import { Sep24 } from "./Sep24";
-import { Sep38 } from "./Sep38";
+import { Sep6, Transfer } from "./Sep6";
+import { Interactive, Sep24 } from "./Sep24";
+import { Quote, Sep38 } from "./Sep38";
 import { AnchorServiceInfo, TomlInfo, AuthToken } from "../Types";
 import { parseToml } from "../Utils";
 
@@ -23,16 +23,6 @@ type AnchorParams = {
   httpClient: AxiosInstance;
   language: string;
 };
-
-export type Transfer = Sep6;
-
-export type Auth = Sep10;
-
-export type Customer = Sep12;
-
-export type Interactive = Sep24;
-
-export type Quote = Sep38;
 
 /**
  * Build on/off ramps with anchors.

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Asset/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Asset/index.ts
@@ -39,6 +39,9 @@ export class IssuedAssetId extends StellarAssetId {
   }
 }
 
+/**
+ * @alias XLM alias for NativeAssetId class.
+ */
 export type XLM = NativeAssetId;
 
 export class NativeAssetId extends StellarAssetId {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
@@ -22,7 +22,7 @@ import {
 import { AccountKeypair } from "../Horizon/Account";
 import { AuthHeaderSigner } from "./AuthHeaderSigner";
 
-export { WalletSigner, DefaultSigner } from "./WalletSigner";
+export { WalletSigner, DomainSigner, DefaultSigner } from "./WalletSigner";
 
 // Let's prevent exporting this constructor type as
 // we should not create this Anchor class directly.
@@ -32,6 +32,11 @@ type Sep10Params = {
   homeDomain: string;
   httpClient: AxiosInstance;
 };
+
+/**
+ * @alias Auth alias for Sep10 class.
+ */
+export type Auth = Sep10;
 
 /**
  * Sep-10 used for authentication to an external server.

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
@@ -11,6 +11,11 @@ import {
 } from "../Types";
 
 /**
+ * @alias Customer alias for Sep12 class.
+ */
+export type Customer = Sep12;
+
+/**
  * KYC management with Sep-12.
  * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md}
  * Do not create this object directly, use the Anchor class.


### PR DESCRIPTION
Every time a new `Class` is added to the codebase we need to make sure it's also exported on `../src/index.ts` file so devs can actually access it through the `@stellar/typescript-wallet-sdk` npm package.

This PR exports all the following missing classes:
- `Sep6`
- `Sep12`
- `Sep38`
- `StellarAssetId`
- `DomainSigner`

It also exports the aliases below:
- `Transfer` (alias for `Sep6` class)
- `Auth` (alias for `Sep10` class)
- `Customer` (alias for `Sep12` class)
- `Interactive` (alias for `Sep24` class)
- `Quote` (alias for `Sep38` class)
- `XLM` (alias for `NativeAssetId` class)