### PR TITLE
[Key Manager] Add support for 'home_domain' on GET /auth request

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/src/Types/index.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/Types/index.ts
@@ -182,6 +182,7 @@ export interface GetAuthTokenParams {
   challengeToken?: string;
   account?: string;
   clientDomain?: string;
+  homeDomain?: string;
   onChallengeTransactionSignature?: (tx: Transaction) => Promise<Transaction>;
 }
 

--- a/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
@@ -225,24 +225,29 @@ export class KeyManager {
    * https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0010.md
    *
    * @async
-   * @param {object} params Params object
+   * @param {object} params Params object.
    * @param {string} params.id The user's key to authenticate. The id is
    *                           computed as `sha1(private key + public key)`.
-   * @param {string} params.password The password that will decrypt that secret
-   * @param {string} params.authServer The URL of the authentication server
+   * @param {string} params.password The password that will decrypt that secret.
+   * @param {string} params.authServer The URL of the authentication server.
    * @param {Array} params.authServerHomeDomains The home domain(s) of the
-   *                                             authentication server
+   *                                             authentication server.
    * @param {string} params.authServerKey Check the challenge transaction
    *                                      for this key as source and signature.
-   * @param {string} params.clientDomain a domain hosting a SEP-1 stellar.toml
-   * containing a SIGNING_KEY used for verifying the client domain.
+   * @param {string} params.clientDomain A domain hosting a SEP-1 stellar.toml
+   * containing a SIGNING_KEY used for verifying the client domain. This will
+   * be used as the 'client_domain' param on the GET /authServer request.
+   * @param {string} params.homeDomain Servers that generate tokens for multiple
+   * Home Domains can use this parameter to identify which home domain the Client
+   * hopes to authenticate with. This will be used as the 'home_domain' param
+   * on the GET /authServer request.
    * @param {Function} params.onChallengeTransactionSignature When
    * `params.clientDomain` is set, you need to provide a function that will add
    * the signature identified by the SIGNING_KEY present on your client domain's
    * toml file.
    * @param {string} [params.account] The authenticating public key. If not
    * provided, then the signers's public key will be used instead.
-   * @returns {Promise<string>} authToken JWT
+   * @returns {Promise<string>} authToken JWT.
    */
   // tslint:enable max-line-length
   public async fetchAuthToken(params: GetAuthTokenParams): Promise<string> {
@@ -254,6 +259,7 @@ export class KeyManager {
       challengeToken,
       authServerHomeDomains,
       clientDomain,
+      homeDomain,
       onChallengeTransactionSignature = (tx: Transaction) =>
         Promise.resolve(tx),
     } = params;
@@ -301,6 +307,10 @@ export class KeyManager {
 
     if (clientDomain) {
       challengeUrl += `&client_domain=${encodeURIComponent(clientDomain)}`;
+    }
+
+    if (homeDomain) {
+      challengeUrl += `&home_domain=${encodeURIComponent(homeDomain)}`;
     }
 
     let headers = {};

--- a/@stellar/typescript-wallet-sdk-km/test/keyManager.test.ts
+++ b/@stellar/typescript-wallet-sdk-km/test/keyManager.test.ts
@@ -508,6 +508,107 @@ describe("fetchAuthToken", () => {
     );
   });
 
+  test("Sets home domain when fetching challenges", async () => {
+    const authServer = "https://www.stellar.org/auth";
+    const password = "very secure password";
+
+    const keyNetwork = Networks.TESTNET;
+
+    const token = "👍";
+    const accountKey = Keypair.random();
+    const account = new Account(accountKey.publicKey(), "-1");
+
+    // set up the manager
+    const testStore = new MemoryKeyStore();
+    const testKeyManager = new KeyManager({
+      keyStore: testStore,
+    });
+
+    testKeyManager.registerEncrypter(IdentityEncrypter);
+
+    const keypair = Keypair.master(keyNetwork);
+
+    // A Base64 digit represents 6 bits, to generate a random 64 bytes
+    // base64 string, we need 48 random bytes = (64 * 6)/8
+    //
+    // Each Base64 digit is in ASCII and each ASCII characters when
+    // turned into binary represents 8 bits = 1 bytes.
+    const value = randomBytes(48).toString("base64");
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: keyNetwork,
+    })
+      .addOperation(
+        Operation.manageData({
+          name: `stellar.org auth`,
+          value,
+          source: keypair.publicKey(),
+        }),
+      )
+      .addOperation(
+        Operation.manageData({
+          name: "web_auth_domain",
+          value: new URL(authServer).hostname,
+          source: account.accountId(),
+        }),
+      )
+      .setTimeout(300)
+      .build();
+
+    tx.sign(accountKey);
+
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            transaction: tx.toXDR(),
+            network_passphrase: keyNetwork,
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token,
+            status: 1,
+            message: "Good job friend",
+          }),
+        ),
+      );
+
+    // save this key
+    const keyMetadata = await testKeyManager.storeKey({
+      key: {
+        type: KeyType.plaintextKey,
+        publicKey: keypair.publicKey(),
+        privateKey: keypair.secret(),
+        network: keyNetwork,
+      },
+      password,
+      encrypterName: "IdentityEncrypter",
+    });
+
+    await testKeyManager.fetchAuthToken({
+      id: keyMetadata.id,
+      password,
+      authServer,
+      authServerKey: account.accountId(),
+      authServerHomeDomains: ["stellar.org"],
+      clientDomain: "someclientdomain.com",
+      homeDomain: "somehomedomain.com",
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      "https://www.stellar.org/auth?account=" +
+        "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H" +
+        "&client_domain=someclientdomain.com&home_domain=somehomedomain.com",
+      { headers: {} },
+    );
+  });
+
   test("Sets additional signature", async () => {
     const authServer = "https://www.stellar.org/auth";
     const password = "very secure password";


### PR DESCRIPTION
Related: [[TS] Add support for Sep-10 "home_domain" param on km package](https://stellarorg.atlassian.net/jira/software/c/projects/WAL/boards/37?selectedIssue=WAL-1492)