### PR TITLE
[Beta] Release 1.7.0

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,12 @@
+# Release notes - Typescript Wallet SDK Key Manager - 1.7.0
+
+### Added
+* Support for `home_domain` on `GET /auth` request (#151)
+
+### Fixed
+* Replace `tweetnacl-util` with `@stablelib` packages (#149)
+  * ^ this fixes the lib `crashing` on `React Native` environment
+
 # Release notes - Typescript Wallet SDK Key Manager - 1.6.0
 
 ### Added

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "engines": {
     "node": ">=18"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,8 @@
+# Release notes - Typescript Wallet SDK Soroban - 1.7.0
+
+### Added
+* Bump version to 1.7.0
+
 # Release notes - Typescript Wallet SDK Soroban - 1.6.0
 
 ### Added

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "engines": {
     "node": ">=18"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,23 @@
+# Release notes - Typescript Wallet SDK - 1.7.0
+
+### Fixed
+* Replace `tweetnacl-util` with `@stablelib` packages (#149)
+   * this fixes the lib `crashing` on `React Native` environment
+* Export missing classes and aliases (#150)
+  * with this change devs can now access the following classes:
+    * `Sep6`
+    * `Sep12`
+    * `Sep38`
+    * `StellarAssetId`
+    * `DomainSigner`
+  * And aliases:
+    * `Transfer` (alias for `Sep6` class)
+    * `Auth` (alias for `Sep10` class)
+    * `Customer` (alias for `Sep12` class)
+    * `Interactive` (alias for `Sep24` class)
+    * `Quote` (alias for `Sep38` class)
+    * `XLM` (alias for `NativeAssetId` class)
+
 # Release notes - Typescript Wallet SDK - 1.6.0
 
 ### Added

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
Bump version to 1.7.0  + Changelogs.

Merging to `develop` so we generate the `1.7.0-beta.{timestamp}` build for testing before the `main` release.