### PR TITLE
uses v2 syntax for docker compose

### DIFF
--- a/.github/workflows/integration.anchorPlatformTest.yml
+++ b/.github/workflows/integration.anchorPlatformTest.yml
@@ -11,11 +11,11 @@ jobs:
           repository: stellar/java-stellar-anchor-sdk
       - name: Build docker
         run:
-          docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk11 -t
+          docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk17 -t
           anchor-platform:local ./
       - name: Run docker
         run:
-          docker-compose -f
+          docker compose -f
           service-runner/src/main/resources/docker-compose.yaml up -d
       - name: Wait for docker to be ready
         run: sleep 90 && curl http://localhost:8080/.well-known/stellar.toml

--- a/.github/workflows/integration.recoveryTest.yml
+++ b/.github/workflows/integration.recoveryTest.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Start docker
         run:
-          docker-compose -f
+          docker compose -f
           @stellar/typescript-wallet-sdk/test/docker/docker-compose.yml up -d
       - uses: actions/setup-node@v2
         with:
@@ -19,5 +19,5 @@ jobs:
       - name: Print Docker Logs
         if: always() # This ensures that the logs are printed even if the tests fail
         run:
-          docker-compose -f
+          docker compose -f
           @stellar/typescript-wallet-sdk/test/docker/docker-compose.yml logs


### PR DESCRIPTION
What
Uses V2 syntax of docker compose because the action image that this runs in no longer supports v1.
https://github.com/actions/runner-images/issues/9557