### PR TITLE
Make 'withdraw_anchor_account' field optional

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -159,6 +159,13 @@ export class WithdrawalTxNotPendingUserTransferStartError extends Error {
   }
 }
 
+export class WithdrawalTxMissingDestinationError extends Error {
+  constructor() {
+    super(`Withdrawal transaction missing withdraw_anchor_account field`);
+    Object.setPrototypeOf(this, WithdrawalTxMissingDestinationError.prototype);
+  }
+}
+
 export class WithdrawalTxMissingMemoError extends Error {
   constructor() {
     super(`Withdrawal transaction missing memo`);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
@@ -194,7 +194,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
 
   /**
    * Swap assets using the Stellar network. This swaps using the
-   * pathPaymentStrictReceive operation.
+   * pathPaymentStrictSend operation.
    * @param {StellarAssetId} fromAsset - The source asset to be sent.
    * @param {StellarAssetId} toAsset - The destination asset to receive.
    * @param {string} amount - The amount of the source asset to be sent.

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Horizon/Transaction/TransactionBuilder.ts
@@ -15,6 +15,7 @@ import {
   WithdrawalTxMissingMemoError,
   WithdrawalTxNotPendingUserTransferStartError,
   WithdrawalTxMemoError,
+  WithdrawalTxMissingDestinationError,
 } from "../../Exceptions";
 import { StellarAssetId } from "../../Asset";
 import {
@@ -241,6 +242,7 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
    * @param {WithdrawTransaction} transaction - The withdrawal transaction.
    * @param {StellarAssetId} assetId - The asset ID to transfer.
    * @throws {WithdrawalTxNotPendingUserTransferStartError} If the withdrawal transaction status is not pending_user_transfer_start.
+   * @throws {WithdrawalTxMissingDestinationError} If the withdrawal transaction is missing withdraw_anchor_account field.
    * @throws {WithdrawalTxMissingMemoError} If the withdrawal transaction is missing a memo.
    * @throws {WithdrawalTxMemoError} If there is an issue with the withdrawal transaction memo.
    * @returns {TransactionBuilder} The TransactionBuilder instance.
@@ -253,6 +255,11 @@ export class TransactionBuilder extends CommonTransactionBuilder<TransactionBuil
       throw new WithdrawalTxNotPendingUserTransferStartError(
         transaction.status,
       );
+    }
+
+    // We can't send a payment if we don't know the destination address
+    if (!transaction.withdraw_anchor_account) {
+      throw new WithdrawalTxMissingDestinationError();
     }
 
     if (!(transaction.withdraw_memo_type && transaction.withdraw_memo)) {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/anchor.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/anchor.ts
@@ -60,7 +60,7 @@ export interface WithdrawTransaction extends ProcessingAnchorTransaction {
   to?: string;
   withdraw_memo?: string;
   withdraw_memo_type: MemoType;
-  withdraw_anchor_account: string;
+  withdraw_anchor_account?: string;
 }
 
 export type Sep6Transaction = DepositTransaction &


### PR DESCRIPTION
Closes [Make withdraw_anchor_account optional in WithdrawTransaction interface](https://github.com/orgs/stellar/projects/58/views/2?sliceBy%5Bvalue%5D=Iteration+6&pane=issue&itemId=73597662)

This PR makes the `withdraw_anchor_account` field optional for transaction objects that are not in the `pending_user_transfer_start` status, otherwise throws an error.

This PR also adds more tests for the `transferWithdrawalTransaction` function and fixes a JsDoc description for the `swap` function where it was referencing `pathPaymentStrictReceive` instead of `pathPaymentStrictSend`.