### PR TITLE
Add `transaction_id` field to SEP-12 requests

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
@@ -2,13 +2,11 @@ import { AxiosInstance } from "axios";
 import queryString from "query-string";
 import { Sep9InfoRequiredError, CustomerNotFoundError } from "../Exceptions";
 import {
-  CustomerBinaryInfoMap,
   GetCustomerParams,
   GetCustomerResponse,
   AddCustomerResponse,
   AddCustomerParams,
   AuthToken,
-  CustomerInfoMap,
 } from "../Types";
 import { camelToSnakeCaseObject } from "../Utils";
 
@@ -98,7 +96,7 @@ export class Sep12 {
     memo,
     transactionId,
   }: AddCustomerParams): Promise<AddCustomerResponse> {
-    let customerMap: CustomerInfoMap | CustomerBinaryInfoMap = {
+    let customerMap: { [key: string]: string | Buffer } = {
       ...sep9Info,
       ...sep9BinaryInfo,
     };
@@ -151,7 +149,7 @@ export class Sep12 {
     memo,
     transactionId,
   }: AddCustomerParams): Promise<AddCustomerResponse> {
-    let customerMap: CustomerInfoMap | CustomerBinaryInfoMap = {};
+    let customerMap: { [key: string]: string | Buffer } = {};
     if (id) {
       customerMap["id"] = id;
     }

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Customer/index.ts
@@ -2,13 +2,15 @@ import { AxiosInstance } from "axios";
 import queryString from "query-string";
 import { Sep9InfoRequiredError, CustomerNotFoundError } from "../Exceptions";
 import {
-  CustomerInfoMap,
+  CustomerBinaryInfoMap,
   GetCustomerParams,
   GetCustomerResponse,
   AddCustomerResponse,
   AddCustomerParams,
   AuthToken,
+  CustomerInfoMap,
 } from "../Types";
+import { camelToSnakeCaseObject } from "../Utils";
 
 /**
  * @alias Customer alias for Sep12 class.
@@ -52,17 +54,20 @@ export class Sep12 {
    * Retrieve customer information. All arguments are optional, but at least one
    * must be given. For more information:
    * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#request}
-   * @param {object} params - The parameters for retrieving customer information.
+   * @param {GetCustomerParams} params - The parameters for retrieving customer information.
    * @param {string} [params.id] - The id of the customer .
    * @param {string} [params.type] - The type of action the customer is being KYCd for.
    * @see {@link https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0012.md#type-specification}
    * @param {string} [params.memo] - A memo associated with the customer.
    * @param {string} [params.lang] - The desired language. Defaults to "en".
+   * @param {string} [params.transactionId] - The id of the transaction that the customer is
+   * being KYC'ed for.
    * @returns {Promise<GetCustomerResponse>} The customer information.
    * @throws {CustomerNotFoundError} If the customer is not found.
    */
   async getCustomer(params: GetCustomerParams): Promise<GetCustomerResponse> {
-    const qs = queryString.stringify(params);
+    const qs = queryString.stringify(camelToSnakeCaseObject(params));
+
     const resp = await this.httpClient.get(`${this.baseUrl}/customer?${qs}`, {
       headers: this.headers,
     });
@@ -78,28 +83,38 @@ export class Sep12 {
    * @param {AddCustomerParams} params - The parameters for adding a customer.
    * @param {CustomerInfoMap} [params.sep9Info] - Customer information. What fields you should
    * give is indicated by the anchor.
-   * @param {CustomerInfoMap} [params.sep9BinaryInfo] - Customer information that is in binary
+   * @param {CustomerBinaryInfoMap} [params.sep9BinaryInfo] - Customer information that is in binary
    * format (eg. Buffer of an image).
    * @param {string} [params.type] - The type of the customer.
    * @param {string} [params.memo] - A memo associated with the customer.
+   * @param {string} [params.transactionId] - The id of the transaction that the customer is
+   * being KYC'ed for.
    * @returns {Promise<AddCustomerResponse>} Add customer response.
    */
   async add({
-    sep9Info,
-    sep9BinaryInfo,
+    sep9Info = {},
+    sep9BinaryInfo = {},
     type,
     memo,
+    transactionId,
   }: AddCustomerParams): Promise<AddCustomerResponse> {
-    let customerMap: CustomerInfoMap = { ...sep9Info, ...sep9BinaryInfo };
+    let customerMap: CustomerInfoMap | CustomerBinaryInfoMap = {
+      ...sep9Info,
+      ...sep9BinaryInfo,
+    };
+
     if (type) {
       customerMap = { type, ...customerMap };
     }
     if (memo) {
       customerMap["memo"] = memo;
     }
+    if (transactionId) {
+      customerMap["transaction_id"] = transactionId;
+    }
 
     // Check if binary data given so can adjust headers
-    const includesBinary = sep9BinaryInfo && Object.keys(sep9BinaryInfo).length;
+    const includesBinary = Object.keys(sep9BinaryInfo).length > 0;
     const resp = await this.httpClient.put(
       `${this.baseUrl}/customer`,
       customerMap,
@@ -118,22 +133,25 @@ export class Sep12 {
    * @param {AddCustomerParams} params - The parameters for adding a customer.
    * @param {CustomerInfoMap} [params.sep9Info] - Customer information. What fields you should
    * give is indicated by the anchor.
-   * @param {CustomerInfoMap} [params.sep9BinaryInfo] - Customer information that is in binary
+   * @param {CustomerBinaryInfoMap} [params.sep9BinaryInfo] - Customer information that is in binary
    * format (eg. Buffer of an image).
    * @param {string} [params.id] - The id of the customer.
    * @param {string} [params.type] - The type of the customer.
    * @param {string} [params.memo] - A memo associated with the customer.
+   * @param {string} [params.transactionId] - The id of the transaction that the customer is
+   * being KYC'ed for.
    * @returns {Promise<AddCustomerResponse>} Add customer response.
    * @throws {Sep9InfoRequiredError} If no SEP-9 info is given.
    */
   async update({
-    sep9Info,
-    sep9BinaryInfo,
+    sep9Info = {},
+    sep9BinaryInfo = {},
     id,
     type,
     memo,
+    transactionId,
   }: AddCustomerParams): Promise<AddCustomerResponse> {
-    let customerMap: CustomerInfoMap = {};
+    let customerMap: CustomerInfoMap | CustomerBinaryInfoMap = {};
     if (id) {
       customerMap["id"] = id;
     }
@@ -143,13 +161,16 @@ export class Sep12 {
     if (memo) {
       customerMap["memo"] = memo;
     }
+    if (transactionId) {
+      customerMap["transaction_id"] = transactionId;
+    }
     if (!Object.keys({ ...sep9Info, ...sep9BinaryInfo }).length) {
       throw new Sep9InfoRequiredError();
     }
     customerMap = { ...customerMap, ...sep9Info, ...sep9BinaryInfo };
 
     // Check if binary data given so can adjust headers
-    const includesBinary = sep9BinaryInfo && Object.keys(sep9BinaryInfo).length;
+    const includesBinary = Object.keys(sep9BinaryInfo).length > 0;
     const resp = await this.httpClient.put(
       `${this.baseUrl}/customer`,
       customerMap,
@@ -164,7 +185,7 @@ export class Sep12 {
 
   /**
    * Deletes a customer.
-   * @param {string} accountAddress - The account address of the customer to delete.
+   * @param {string} [accountAddress] - The account address of the customer to delete.
    * @param {string} [memo] - An optional memo for customer identification.
    */
   async delete(accountAddress?: string, memo?: string) {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
@@ -3,7 +3,7 @@ export type CustomerInfoMap = {
 };
 
 export type CustomerBinaryInfoMap = {
-  [key: string]: string | Buffer;
+  [key: string]: Buffer | string;
 };
 
 export enum Sep12Status {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
@@ -3,7 +3,7 @@ export type CustomerInfoMap = {
 };
 
 export type CustomerBinaryInfoMap = {
-  [key: string]: Buffer | string;
+  [key: string]: Buffer;
 };
 
 export enum Sep12Status {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep12.ts
@@ -2,6 +2,10 @@ export type CustomerInfoMap = {
   [key: string]: string;
 };
 
+export type CustomerBinaryInfoMap = {
+  [key: string]: string | Buffer;
+};
+
 export enum Sep12Status {
   ACCEPTED = "ACCEPTED",
   PROCESSING = "PROCESSING",
@@ -38,6 +42,7 @@ export type GetCustomerParams = {
   type?: string;
   memo?: string;
   lang?: string;
+  transactionId?: string;
 };
 
 export type GetCustomerResponse = {
@@ -50,10 +55,11 @@ export type GetCustomerResponse = {
 
 export type AddCustomerParams = {
   sep9Info?: CustomerInfoMap;
-  sep9BinaryInfo?: CustomerInfoMap;
+  sep9BinaryInfo?: CustomerBinaryInfoMap;
   id?: string;
   memo?: string;
   type?: string;
+  transactionId?: string;
 };
 
 export type AddCustomerResponse = {


### PR DESCRIPTION
Also improves typing by adding a separate `CustomerBinaryInfoMap` type only for the binary (Buffer) fields.

Closes: [Add transaction id to SEP-12 requests](https://github.com/orgs/stellar/projects/58/views/2?sliceBy%5Bvalue%5D=Iteration+6&pane=issue&itemId=73597661)