### PR TITLE
Deprecate `getServicesInfo()` in favor of `Sep24.info()`

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep38.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep38.ts
@@ -63,6 +63,7 @@ export class Sep38 {
    * If `shouldRefresh` is set to `true`, it fetches fresh values; otherwise, it returns cached values if available.
    * @param {boolean} [shouldRefresh=false] - Flag to force a refresh of TOML values.
    * @returns {Promise<Sep38Info>} - SEP-38 information about the anchor.
+   * @throws {ServerRequestFailedError} If the server request to fetch information fails.
    */
   async info(shouldRefresh?: boolean): Promise<Sep38Info> {
     if (this.sep38Info && !shouldRefresh) {
@@ -70,7 +71,6 @@ export class Sep38 {
     }
 
     const { anchorQuoteServer } = await this.anchor.sep1();
-
     try {
       const resp = await this.httpClient.get(`${anchorQuoteServer}/info`, {
         headers: this.headers,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
@@ -61,6 +61,7 @@ export class Sep6 {
    * If `shouldRefresh` is set to `true`, it fetches fresh values; otherwise, it returns cached values if available.
    * @param {boolean} [shouldRefresh=false] - Flag to force a refresh of TOML values.
    * @returns {Promise<Sep6Info>} - SEP-6 information about the anchor.
+   * @throws {ServerRequestFailedError} If the server request to fetch information fails.
    */
   async info(shouldRefresh?: boolean): Promise<Sep6Info> {
     if (this.anchorInfo && !shouldRefresh) {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts
@@ -60,17 +60,23 @@ export class Sep6 {
    * Get SEP-6 anchor information.
    * If `shouldRefresh` is set to `true`, it fetches fresh values; otherwise, it returns cached values if available.
    * @param {boolean} [shouldRefresh=false] - Flag to force a refresh of TOML values.
+   * @param {string} [lang=this.anchor.language] - The language in which to retrieve information.
    * @returns {Promise<Sep6Info>} - SEP-6 information about the anchor.
    * @throws {ServerRequestFailedError} If the server request to fetch information fails.
    */
-  async info(shouldRefresh?: boolean): Promise<Sep6Info> {
+  async info(
+    shouldRefresh?: boolean,
+    lang: string = this.anchor.language,
+  ): Promise<Sep6Info> {
     if (this.anchorInfo && !shouldRefresh) {
       return this.anchorInfo;
     }
 
     const { transferServer } = await this.anchor.sep1();
     try {
-      const resp = await this.httpClient.get(`${transferServer}/info`);
+      const resp = await this.httpClient.get(
+        `${transferServer}/info?lang=${lang}`,
+      );
       this.anchorInfo = resp.data;
       return resp.data;
     } catch (e) {

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts
@@ -184,10 +184,12 @@ export class Anchor {
   }
 
   /**
-   * Get information about an Anchor.
+   * @deprecated Please use sep24().info() instead.
+   *
+   * Get SEP-24 anchor information.
    * @param {string} [lang=this.language] - The language in which to retrieve information.
-   * @returns {Promise<AnchorServiceInfo>} An object containing information about the Anchor.
-   * @throws {ServerRequestFailedError} If the http request fails.
+   * @returns {Promise<AnchorServiceInfo>} - SEP-24 information about the anchor.
+   * @throws {ServerRequestFailedError} If the server request to fetch information fails.
    */
   async getServicesInfo(
     lang: string = this.language,
@@ -198,15 +200,8 @@ export class Anchor {
     try {
       const resp = await this.httpClient.get(
         `${transferServerEndpoint}/info?lang=${lang}`,
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-        },
       );
-
       const servicesInfo: AnchorServiceInfo = resp.data;
-
       return servicesInfo;
     } catch (e) {
       throw new ServerRequestFailedError(e);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/anchor.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/anchor.ts
@@ -2,25 +2,20 @@ import { MemoType } from "@stellar/stellar-sdk";
 import { Optional } from "utility-types";
 
 import { AuthToken } from "./auth";
+import { Sep24AssetInfo, Sep24AssetInfoMap, Sep24Info } from "./sep24";
 
-export interface AnchorServiceInfo {
-  deposit: AssetInfoMap;
-  withdraw: AssetInfoMap;
-  fee: { enabled: boolean };
-  features: { account_creation: boolean; claimable_balances: boolean };
-}
-
-export interface AssetInfoMap {
-  [asset_code: string]: AnchorServiceAsset;
-}
-
-export interface AnchorServiceAsset {
-  enabled: boolean;
-  min_amount: number;
-  max_amount: number;
-  fee_fixed: number;
-  fee_percent: number;
-}
+/**
+ * @deprecated Please use Sep24Info interface instead.
+ */
+export type AnchorServiceInfo = Sep24Info;
+/**
+ * @deprecated Please use Sep24AssetInfoMap interface instead.
+ */
+export type AssetInfoMap = Sep24AssetInfoMap;
+/**
+ * @deprecated Please use Sep24AssetInfo interface instead.
+ */
+export type AnchorServiceAsset = Sep24AssetInfo;
 
 export interface BaseTransaction {
   id: string;

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep24.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep24.ts
@@ -2,6 +2,25 @@ import { Memo } from "@stellar/stellar-sdk";
 
 import { AuthToken } from "./auth";
 
+export interface Sep24Info {
+  deposit: Sep24AssetInfoMap;
+  withdraw: Sep24AssetInfoMap;
+  fee: { enabled: boolean };
+  features: { account_creation: boolean; claimable_balances: boolean };
+}
+
+export interface Sep24AssetInfoMap {
+  [asset_code: string]: Sep24AssetInfo;
+}
+
+export interface Sep24AssetInfo {
+  enabled: boolean;
+  min_amount: number;
+  max_amount: number;
+  fee_fixed: number;
+  fee_percent: number;
+}
+
 export enum FLOW_TYPE {
   DEPOSIT = "deposit",
   WITHDRAW = "withdraw",

--- a/@stellar/typescript-wallet-sdk/test/wallet.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/wallet.test.ts
@@ -156,7 +156,7 @@ describe("Anchor", () => {
     expect(signedByClient).toBe(true);
     expect(signedByDomain).toBe(true);
   });
-  it("should get anchor services info", async () => {
+  it("(deprecated) should get anchor services info", async () => {
     let serviceInfo = await anchor.sep24().getServicesInfo();
     expect(serviceInfo.deposit).toBeTruthy();
     expect(serviceInfo.withdraw).toBeTruthy();
@@ -165,6 +165,23 @@ describe("Anchor", () => {
     serviceInfo = await anchor.interactive().getServicesInfo();
     expect(serviceInfo.deposit).toBeTruthy();
     expect(serviceInfo.withdraw).toBeTruthy();
+  });
+
+  it("should get anchor Sep-24 info", async () => {
+    const sep24Info = await anchor.sep24().info();
+    expect(sep24Info.deposit).toBeTruthy();
+    expect(sep24Info.withdraw).toBeTruthy();
+  });
+
+  it("should get anchor Sep-6 info", async () => {
+    const sep6Info = await anchor.sep6().info();
+    expect(sep6Info["deposit-exchange"]).toBeTruthy();
+    expect(sep6Info["withdraw-exchange"]).toBeTruthy();
+  });
+
+  it("should get anchor Sep-38 info", async () => {
+    const sep38Info = await anchor.sep38().info();
+    expect(sep38Info.assets).toBeTruthy();
   });
 
   it("should give interactive deposit url", async () => {


### PR DESCRIPTION
We currently have the below `get info` functions for the related classes and SEPs:
- [Sep6.info()](https://github.com/stellar/typescript-wallet-sdk/blob/main/%40stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep6.ts#L65): hits `GET /info` for the `Sep6 server`
- [Sep38.info()](https://github.com/stellar/typescript-wallet-sdk/blob/main/%40stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep38.ts#L67): hits `GET /info` for the `Sep38 server`
- [Sep24.getServicesInfo()](https://github.com/stellar/typescript-wallet-sdk/blob/main/%40stellar/typescript-wallet-sdk/src/walletSdk/Anchor/Sep24.ts#L183): hits `GET /info` for the `Sep24 server`
- [Anchor.getServicesInfo()](https://github.com/stellar/typescript-wallet-sdk/blob/main/%40stellar/typescript-wallet-sdk/src/walletSdk/Anchor/index.ts#L192): also hits `GET /info` for the `same Sep24 server` which could be `confusing`
 
The proposal of this PR is to `deprecate` both `getServicesInfo()` functions and consolidate them into a single `info()` function like the below for consistency and simplicity:
- `Sep6.info():` hits `GET /info` for the `Sep6 server`
- `Sep38.info()`: hits `GET /info` for the `Sep38 server`
- `Sep24.info()`: hits `GET /info` for the `Sep24 server`

This PR also adds support for the `lang` parameter on [Sep6.info()](https://github.com/stellar/typescript-wallet-sdk/pull/166/files#diff-6deabbb345fdb9b022d3f0daddf6fe94bb0030d34d389bf7f993cd7f9b38c663R69) and [Sep24.info()](https://github.com/stellar/typescript-wallet-sdk/pull/166/files#diff-166da6ffe01fd5f63003df55d66583420c883457a4edd9420f6a281384b8e11dR72) as covered by the [Sep-6](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0006.md#info) and [Sep-24](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#info) specs.
