### PR TITLE
Point Anchor Platform integration tests to dev instance

### DIFF
--- a/.github/workflows/integration.anchorPlatformTest.yml
+++ b/.github/workflows/integration.anchorPlatformTest.yml
@@ -5,20 +5,6 @@ jobs:
     name: anchor platform test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Java Anchor SDK
-        uses: actions/checkout@v2
-        with:
-          repository: stellar/java-stellar-anchor-sdk
-      - name: Build docker
-        run:
-          docker build --build-arg BASE_IMAGE=gradle:7.6.4-jdk17 -t
-          anchor-platform:local ./
-      - name: Run docker
-        run:
-          docker compose -f
-          service-runner/src/main/resources/docker-compose.yaml up -d
-      - name: Wait for docker to be ready
-        run: sleep 300 && curl http://localhost:8080/.well-known/stellar.toml
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:

--- a/@stellar/typescript-wallet-sdk/test/integration/README.md
+++ b/@stellar/typescript-wallet-sdk/test/integration/README.md
@@ -28,11 +28,6 @@ against.
 
 ## To run tests locally:
 
-- follow the steps defined in the
-  (.github/workflows/integration.anchorPlatformTest.yml)[https://github.com/stellar/typescript-wallet-sdk/blob/main/.github/workflows/integration.anchorPlatformTest.yml]
-  file locally
-
-1. Clone the java-stellar-anchor-sdk repo locally
-2. Run the docker build command
-3. Run the docker command
-4. Run the anchorPlatform tests from this repo
+```
+yarn test:anchorplatform:ci
+```

--- a/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
@@ -6,7 +6,7 @@ let wallet;
 let stellar;
 let anchor;
 let accountKp;
-const anchorUrl = "http://localhost:8080";
+const anchorUrl = "https://anchor-sep-server-dev.stellar.org/";
 
 describe("Anchor Platform Integration Tests", () => {
   beforeAll(async () => {

--- a/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/integration/anchorplatform.test.ts
@@ -69,6 +69,7 @@ describe("Anchor Platform Integration Tests", () => {
       params: {
         asset_code: "USDC",
         account: accountKp.publicKey,
+        type: "SEPA",
       },
     });
     expect(dResp.id).toBeTruthy();


### PR DESCRIPTION
We are updating secret management in the Anchor Platform repo to require specifying a `.env` in order to start docker-compose. This breaks the Anchor Platform integration tests in this repository so this PR updates the test to point to our dev instance instead.