### PR TITLE
Fix TypeError crash in SEP-7 `replace` parameter parsing

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
@@ -6,6 +6,7 @@ export enum Sep7OperationType {
 }
 
 export const URI_MSG_MAX_LENGTH = 300;
+export const URI_REPLACE_MAX_LENGTH = 4096;
 
 export type Sep7Replacement = {
   id: string;

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -164,6 +164,15 @@ export const sep7ReplacementsFromString = (
 
   const [txrepString, hintsString] = replacements.split(HINT_DELIMITER);
 
+  const txrepList = txrepString.split(LIST_DELIMITER);
+  const txrepIds: string[] = [];
+  txrepList.forEach((item) => {
+    const id = item.split(ID_DELIMITER)[1];
+    if (id && txrepIds.indexOf(id) === -1) {
+      txrepIds.push(id);
+    }
+  });
+
   const hintsMap: { [id: string]: string } = {};
 
   if (hintsString) {
@@ -173,7 +182,17 @@ export const sep7ReplacementsFromString = (
       .forEach(([id, hint]) => (hintsMap[id] = hint));
   }
 
-  const txrepList = txrepString.split(LIST_DELIMITER);
+  const hintIds = Object.keys(hintsMap);
+
+  const isBalanced =
+    txrepIds.length === hintIds.length &&
+    txrepIds.every((id) => hintsMap.hasOwnProperty(id));
+
+  if (!isBalanced) {
+    throw new Sep7InvalidUriError(
+      "the 'replace' parameter has unbalanced reference identifiers",
+    );
+  }
 
   const replacementsList = txrepList
     .map((item) => item.split(ID_DELIMITER))

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -7,6 +7,7 @@ import {
   IsValidSep7UriResult,
   WEB_STELLAR_SCHEME,
   URI_MSG_MAX_LENGTH,
+  URI_REPLACE_MAX_LENGTH,
 } from "../Types";
 import {
   Sep7InvalidUriError,
@@ -162,7 +163,7 @@ export const sep7ReplacementsFromString = (
     return [];
   }
 
-  if (replacements.length > 4096) {
+  if (replacements.length > URI_REPLACE_MAX_LENGTH) {
     throw new Sep7InvalidUriError(
       "the 'replace' parameter exceeds the maximum allowed length",
     );
@@ -174,9 +175,9 @@ export const sep7ReplacementsFromString = (
   const txrepIds: string[] = [];
   txrepList.forEach((item) => {
     const parts = item.split(ID_DELIMITER);
-    if (parts.length < 2 || !parts[1]) {
+    if (parts.length < 2 || !parts[0] || !parts[1]) {
       throw new Sep7InvalidUriError(
-        "the 'replace' parameter has an entry missing a reference identifier",
+        "the 'replace' parameter has an entry missing a path or reference identifier",
       );
     }
     const id = parts[1];
@@ -189,9 +190,15 @@ export const sep7ReplacementsFromString = (
 
   if (hintsString) {
     const hintsList = hintsString.split(LIST_DELIMITER);
-    hintsList
-      .map((item) => item.split(ID_DELIMITER))
-      .forEach(([id, hint]) => (hintsMap[id] = hint));
+    hintsList.forEach((item) => {
+      const parts = item.split(ID_DELIMITER);
+      if (parts.length < 2 || !parts[0] || !parts[1]) {
+        throw new Sep7InvalidUriError(
+          "the 'replace' parameter has a hint entry missing an identifier or hint value",
+        );
+      }
+      hintsMap[parts[0]] = parts[1];
+    });
   }
 
   const hintIds = Object.keys(hintsMap);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -167,8 +167,14 @@ export const sep7ReplacementsFromString = (
   const txrepList = txrepString.split(LIST_DELIMITER);
   const txrepIds: string[] = [];
   txrepList.forEach((item) => {
-    const id = item.split(ID_DELIMITER)[1];
-    if (id && txrepIds.indexOf(id) === -1) {
+    const parts = item.split(ID_DELIMITER);
+    if (parts.length < 2 || !parts[1]) {
+      throw new Sep7InvalidUriError(
+        "the 'replace' parameter has an entry missing a reference identifier",
+      );
+    }
+    const id = parts[1];
+    if (txrepIds.indexOf(id) === -1) {
       txrepIds.push(id);
     }
   });

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -186,7 +186,7 @@ export const sep7ReplacementsFromString = (
 
   const isBalanced =
     txrepIds.length === hintIds.length &&
-    txrepIds.every((id) => hintsMap.hasOwnProperty(id));
+    txrepIds.every((id) => Object.prototype.hasOwnProperty.call(hintsMap, id));
 
   if (!isBalanced) {
     throw new Sep7InvalidUriError(

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -163,13 +163,15 @@ export const sep7ReplacementsFromString = (
   }
 
   const [txrepString, hintsString] = replacements.split(HINT_DELIMITER);
-  const hintsList = hintsString.split(LIST_DELIMITER);
 
   const hintsMap: { [id: string]: string } = {};
 
-  hintsList
-    .map((item) => item.split(ID_DELIMITER))
-    .forEach(([id, hint]) => (hintsMap[id] = hint));
+  if (hintsString) {
+    const hintsList = hintsString.split(LIST_DELIMITER);
+    hintsList
+      .map((item) => item.split(ID_DELIMITER))
+      .forEach(([id, hint]) => (hintsMap[id] = hint));
+  }
 
   const txrepList = txrepString.split(LIST_DELIMITER);
 

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -162,6 +162,12 @@ export const sep7ReplacementsFromString = (
     return [];
   }
 
+  if (replacements.length > 4096) {
+    throw new Sep7InvalidUriError(
+      "the 'replace' parameter exceeds the maximum allowed length",
+    );
+  }
+
   const [txrepString, hintsString] = replacements.split(HINT_DELIMITER);
 
   const txrepList = txrepString.split(LIST_DELIMITER);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -179,7 +179,7 @@ export const sep7ReplacementsFromString = (
     }
   });
 
-  const hintsMap: { [id: string]: string } = {};
+  const hintsMap = Object.create(null) as Record<string, string>;
 
   if (hintsString) {
     const hintsList = hintsString.split(LIST_DELIMITER);

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -798,6 +798,48 @@ describe("sep7Parser", () => {
     );
   });
 
+  it("sep7ReplacementsFromString() handles replace string without hints (no ';' delimiter)", () => {
+    const str = "sourceAccount:X,operations[0].sourceAccount:Y";
+    const replacements = sep7ReplacementsFromString(str);
+
+    expect(replacements.length).toBe(2);
+
+    expect(replacements[0].id).toBe("X");
+    expect(replacements[0].path).toBe("sourceAccount");
+    expect(replacements[0].hint).toBeUndefined();
+
+    expect(replacements[1].id).toBe("Y");
+    expect(replacements[1].path).toBe("operations[0].sourceAccount");
+    expect(replacements[1].hint).toBeUndefined();
+  });
+
+  it("sep7ReplacementsFromString() handles single replacement without hints", () => {
+    const str = "sourceAccount:X";
+    const replacements = sep7ReplacementsFromString(str);
+
+    expect(replacements.length).toBe(1);
+    expect(replacements[0].id).toBe("X");
+    expect(replacements[0].path).toBe("sourceAccount");
+    expect(replacements[0].hint).toBeUndefined();
+  });
+
+  it("sep7ReplacementsFromString() returns empty array for undefined/empty input", () => {
+    expect(sep7ReplacementsFromString(undefined)).toEqual([]);
+    expect(sep7ReplacementsFromString("")).toEqual([]);
+  });
+
+  it("Sep7Tx.getReplacements() does not crash on replace param missing hints", () => {
+    const uri = new Sep7Tx(
+      `web+stellar:tx?xdr=test&replace=${encodeURIComponent("sourceAccount:X")}`,
+    );
+
+    const replacements = uri.getReplacements();
+    expect(replacements.length).toBe(1);
+    expect(replacements[0].id).toBe("X");
+    expect(replacements[0].path).toBe("sourceAccount");
+    expect(replacements[0].hint).toBeUndefined();
+  });
+
   it("sep7ReplacementsToString outputs the right string", () => {
     const expected =
       "sourceAccount:X,operations[0].sourceAccount:Y,operations[1].destination:Y;X:account from where you want to pay fees,Y:account that needs the trustline and which will receive the new tokens";

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -798,29 +798,20 @@ describe("sep7Parser", () => {
     );
   });
 
-  it("sep7ReplacementsFromString() handles replace string without hints (no ';' delimiter)", () => {
+  it("sep7ReplacementsFromString() throws on replace string without hints (no ';' delimiter)", () => {
     const str = "sourceAccount:X,operations[0].sourceAccount:Y";
-    const replacements = sep7ReplacementsFromString(str);
-
-    expect(replacements.length).toBe(2);
-
-    expect(replacements[0].id).toBe("X");
-    expect(replacements[0].path).toBe("sourceAccount");
-    expect(replacements[0].hint).toBeUndefined();
-
-    expect(replacements[1].id).toBe("Y");
-    expect(replacements[1].path).toBe("operations[0].sourceAccount");
-    expect(replacements[1].hint).toBeUndefined();
+    expect(() => sep7ReplacementsFromString(str)).toThrow(Sep7InvalidUriError);
   });
 
-  it("sep7ReplacementsFromString() handles single replacement without hints", () => {
+  it("sep7ReplacementsFromString() throws on single replacement without hints", () => {
     const str = "sourceAccount:X";
-    const replacements = sep7ReplacementsFromString(str);
+    expect(() => sep7ReplacementsFromString(str)).toThrow(Sep7InvalidUriError);
+  });
 
-    expect(replacements.length).toBe(1);
-    expect(replacements[0].id).toBe("X");
-    expect(replacements[0].path).toBe("sourceAccount");
-    expect(replacements[0].hint).toBeUndefined();
+  it("sep7ReplacementsFromString() throws on unbalanced identifiers", () => {
+    // Spec example: {X} on left but {Y} on right should be rejected
+    const str = "sourceAccount:X;Y:The account";
+    expect(() => sep7ReplacementsFromString(str)).toThrow(Sep7InvalidUriError);
   });
 
   it("sep7ReplacementsFromString() returns empty array for undefined/empty input", () => {
@@ -828,16 +819,12 @@ describe("sep7Parser", () => {
     expect(sep7ReplacementsFromString("")).toEqual([]);
   });
 
-  it("Sep7Tx.getReplacements() does not crash on replace param missing hints", () => {
+  it("Sep7Tx.getReplacements() throws on replace param missing hints", () => {
     const uri = new Sep7Tx(
       `web+stellar:tx?xdr=test&replace=${encodeURIComponent("sourceAccount:X")}`,
     );
 
-    const replacements = uri.getReplacements();
-    expect(replacements.length).toBe(1);
-    expect(replacements[0].id).toBe("X");
-    expect(replacements[0].path).toBe("sourceAccount");
-    expect(replacements[0].hint).toBeUndefined();
+    expect(() => uri.getReplacements()).toThrow(Sep7InvalidUriError);
   });
 
   it("sep7ReplacementsToString outputs the right string", () => {

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -11,7 +11,10 @@ import {
   sep7ReplacementsFromString,
   sep7ReplacementsToString,
 } from "../src";
-import { Sep7OperationType } from "../src/walletSdk/Types";
+import {
+  Sep7OperationType,
+  URI_REPLACE_MAX_LENGTH,
+} from "../src/walletSdk/Types";
 import {
   Sep7InvalidUriError,
   Sep7LongMsgError,
@@ -812,6 +815,16 @@ describe("sep7Parser", () => {
     // Spec example: {X} on left but {Y} on right should be rejected
     const str = "sourceAccount:X;Y:The account";
     expect(() => sep7ReplacementsFromString(str)).toThrow(Sep7InvalidUriError);
+  });
+
+  it("sep7ReplacementsFromString() throws when replace string exceeds URI_REPLACE_MAX_LENGTH", () => {
+    const longPath = "a".repeat(URI_REPLACE_MAX_LENGTH);
+    const str = `${longPath}:X;X:hint`;
+    expect(str.length).toBeGreaterThan(URI_REPLACE_MAX_LENGTH);
+    expect(() => sep7ReplacementsFromString(str)).toThrow(Sep7InvalidUriError);
+    expect(() => sep7ReplacementsFromString(str)).toThrow(
+      "the 'replace' parameter exceeds the maximum allowed length",
+    );
   });
 
   it("sep7ReplacementsFromString() returns empty array for undefined/empty input", () => {


### PR DESCRIPTION
### Summary

- Fix unhandled `TypeError` in `sep7ReplacementsFromString` when the `replace` parameter string is missing the `;` hints delimiter
- Add spec-compliant validation that rejects `replace` values with unbalanced reference identifiers
- Add test coverage for invalid replacement strings and edge cases

### Problem

`sep7ReplacementsFromString` calls `.split()` on `hintsString` without checking if it exists. When a `replace` parameter value lacks the `;` delimiter (e.g. `sourceAccount:X` instead of `sourceAccount:X;X:some hint`), the destructuring on line 165 leaves `hintsString` as `undefined`, and the immediate `.split()` call on line 166 throws:

```
TypeError: Cannot read properties of undefined (reading 'split')
```

### Fix

Per the [SEP-7 spec](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#operation-tx):

> The `replace` value is considered invalid unless the `reference_identifier`s are balanced on both sides of the separating semicolon.

The fix:
1. Guards against `undefined` on `hintsString` to prevent the `TypeError`
2. Validates that reference identifiers are balanced between the txrep side and the hints side
3. Throws `Sep7InvalidUriError` with a descriptive message when identifiers are unbalanced, instead of silently accepting invalid input

### Tests added

- Missing hints section (no `;` delimiter) — single and multiple fields — throws `Sep7InvalidUriError`
- Unbalanced identifiers (spec example: `sourceAccount:X;Y:The account`) — throws `Sep7InvalidUriError`
- `undefined` and empty string input — returns `[]`
- End-to-end: `Sep7Tx.getReplacements()` with a URI whose `replace` param has no hints — throws `Sep7InvalidUriError`
- Existing tests for valid replacement strings continue to pass
