### PR TITLE
Verify SEP-10 challenge body integrity after domain signing

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Auth/index.ts
@@ -12,6 +12,7 @@ import {
   ExpiredTokenError,
   ChallengeValidationFailedError,
   NetworkPassphraseMismatchError,
+  DomainSigningModifiedError,
 } from "../Exceptions";
 import {
   AuthenticateParams,
@@ -189,15 +190,27 @@ export class Sep10 {
       networkPassphrase,
     ) as Transaction;
 
-    // check if verifying client domain as well
-    for (const op of transaction.operations) {
-      if (op.type === "manageData" && op.name === "client_domain") {
-        transaction = await walletSigner.signWithDomainAccount({
-          transactionXDR: challengeResponse.transaction,
-          networkPassphrase,
-          accountKp,
-        });
+    const hasClientDomain = transaction.operations.some(
+      (op) => op.type === "manageData" && op.name === "client_domain",
+    );
+
+    if (hasClientDomain) {
+      const originalHash = transaction.hash();
+      const returned = await walletSigner.signWithDomainAccount({
+        transactionXDR: challengeResponse.transaction,
+        networkPassphrase,
+        accountKp,
+      });
+
+      // Transaction.hash() covers the envelope body but excludes signatures, so
+      // a domain signer that only appends its signature preserves the hash. Any
+      // change to the operations, source account, memo, or other body fields
+      // changes the hash and is rejected here.
+      if (!returned.hash().equals(originalHash)) {
+        throw new DomainSigningModifiedError();
       }
+
+      transaction = returned;
     }
 
     walletSigner.signWithClientAccount({ transaction, accountKp });

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -354,6 +354,15 @@ export class DefaultSignerDomainAccountError extends Error {
   }
 }
 
+export class DomainSigningModifiedError extends Error {
+  constructor() {
+    super(
+      "Domain signer returned a transaction whose body differs from the original challenge. Only the client_domain signature should be added.",
+    );
+    Object.setPrototypeOf(this, DomainSigningModifiedError.prototype);
+  }
+}
+
 export class AuthHeaderSigningKeypairRequiredError extends Error {
   constructor() {
     super("Must be SigningKeypair to sign auth header");

--- a/@stellar/typescript-wallet-sdk/test/auth.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/auth.test.ts
@@ -16,7 +16,7 @@ import { randomBytes } from "crypto";
 import axios from "axios";
 import sinon from "sinon";
 
-import { validateToken, Sep10 } from "../src/walletSdk/Auth";
+import { validateToken, Sep10, WalletSigner } from "../src/walletSdk/Auth";
 import {
   Config,
   StellarConfiguration,
@@ -30,6 +30,7 @@ import {
   ChallengeValidationFailedError,
   NetworkPassphraseMismatchError,
   MissingSigningKeyError,
+  DomainSigningModifiedError,
 } from "../src/walletSdk/Exceptions";
 
 const createToken = (payload: Record<string, unknown>): string => {
@@ -614,6 +615,108 @@ describe("Sep10 challenge validation", () => {
       await expect(sep10.authenticate({ accountKp })).rejects.toThrow(
         ChallengeValidationFailedError,
       );
+      expect(postStub.notCalled).toBe(true);
+    });
+  });
+
+  describe("client_domain signing integrity", () => {
+    const buildClientDomainChallenge = (clientKeypair: Keypair) => {
+      const clientDomainKeypair = Keypair.random();
+      return buildChallenge({
+        clientKeypair,
+        additionalOps: [
+          Operation.manageData({
+            name: "client_domain",
+            value: "wallet.example.com",
+            source: clientDomainKeypair.publicKey(),
+          }),
+        ],
+      });
+    };
+
+    it("should accept when domain signer returns the same transaction with an appended signature", async () => {
+      const clientKeypair = Keypair.random();
+      const { xdr, serverKeypair } = buildClientDomainChallenge(clientKeypair);
+
+      const accountKp = SigningKeypair.fromSecret(clientKeypair.secret());
+      const token = createJwt(clientKeypair);
+      const { sep10 } = setupSep10({
+        serverSigningKey: serverKeypair.publicKey(),
+        challengeXdr: xdr,
+        token,
+      });
+
+      const walletSigner: WalletSigner = {
+        signWithClientAccount: ({ transaction, accountKp: kp }) => {
+          transaction.sign(kp.keypair);
+          return transaction;
+        },
+        // eslint-disable-next-line @typescript-eslint/require-await
+        signWithDomainAccount: async ({ transactionXDR }) => {
+          const tx = SdkTransactionBuilder.fromXDR(
+            transactionXDR,
+            networkPassphrase,
+          ) as Transaction;
+          tx.sign(Keypair.random());
+          return tx;
+        },
+      };
+
+      const authToken = await sep10.authenticate({
+        accountKp,
+        clientDomain: "wallet.example.com",
+        walletSigner,
+      });
+      expect(authToken.account).toBe(clientKeypair.publicKey());
+    });
+
+    it("should reject when domain signer returns a transaction with a different body", async () => {
+      const clientKeypair = Keypair.random();
+      const { xdr, serverKeypair } = buildClientDomainChallenge(clientKeypair);
+
+      const accountKp = SigningKeypair.fromSecret(clientKeypair.secret());
+      const token = createJwt(clientKeypair);
+      const { sep10, postStub } = setupSep10({
+        serverSigningKey: serverKeypair.publicKey(),
+        challengeXdr: xdr,
+        token,
+      });
+
+      const differentSource = new Account(clientKeypair.publicKey(), "0");
+      const differentTx = new SdkTransactionBuilder(differentSource, {
+        fee: BASE_FEE,
+        networkPassphrase,
+      })
+        .addOperation(
+          Operation.payment({
+            destination: Keypair.random().publicKey(),
+            asset: Asset.native(),
+            amount: "100",
+          }),
+        )
+        .setTimeout(300)
+        .build();
+
+      const signWithClientAccountSpy = sinon.spy(
+        ({ transaction, accountKp: kp }) => {
+          transaction.sign(kp.keypair);
+          return transaction;
+        },
+      );
+      const walletSigner: WalletSigner = {
+        signWithClientAccount: signWithClientAccountSpy,
+        // eslint-disable-next-line @typescript-eslint/require-await
+        signWithDomainAccount: async () => differentTx,
+      };
+
+      await expect(
+        sep10.authenticate({
+          accountKp,
+          clientDomain: "wallet.example.com",
+          walletSigner,
+        }),
+      ).rejects.toThrow(DomainSigningModifiedError);
+      expect(signWithClientAccountSpy.notCalled).toBe(true);
       expect(postStub.notCalled).toBe(true);
     });
   });

--- a/@stellar/typescript-wallet-sdk/test/auth.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/auth.test.ts
@@ -16,7 +16,7 @@ import { randomBytes } from "crypto";
 import axios from "axios";
 import sinon from "sinon";
 
-import { validateToken, Sep10, WalletSigner } from "../src/walletSdk/Auth";
+import { validateToken, Sep10, type WalletSigner } from "../src/walletSdk/Auth";
 import {
   Config,
   StellarConfiguration,


### PR DESCRIPTION
## Summary

- `Sep10.sign()` now verifies that the transaction returned by the configured `DomainSigner` has the same body hash as the original challenge before signing it with the user's account key. If the body differs, a `DomainSigningModifiedError` is thrown and the user-account signature is not applied.

## Test plan

- [x] Added unit test: *should accept when domain signer returns the same transaction with an appended signature* — confirms the legitimate flow still works.
- [x] Added unit test: *should reject when domain signer returns a transaction with a different body* — confirms a modified envelope causes `DomainSigningModifiedError` before any user-account signing.
- [x] `yarn lint` passes
- [x] `yarn test:ci` passes (249 tests, 0 failures)