### PR TITLE
Release/3.0.1

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,8 @@
+# Release notes - Typescript Wallet SDK Key Manager - 3.0.1
+
+### Fixed
+* `KeyManager.removeKey`: the in-memory cache entry is now actually deleted when `shouldCache: true`, instead of being left stale by a no-op write (#238)
+
 # Release notes - Typescript Wallet SDK Key Manager - 3.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK Soroban - 3.0.1
+* Version bump
+
 # Release notes - Typescript Wallet SDK Soroban - 3.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,10 @@
+# Release notes - Typescript Wallet SDK - 3.0.1
+
+### Fixed
+* SEP-10: verify the auth server returns the same challenge body after `client_domain` re-signing, instead of trusting a server-supplied transaction (#237)
+* `submitWithFeeIncrease`: forward `maxFee` across recursive retries so the cap is enforced on every retry, not just the first (#238)
+* `submitTransaction`: replace the unbounded recursive 504 retry with a bounded equal-jitter exponential backoff loop, avoiding stack overflow during sustained Horizon outages (#238)
+
 # Release notes - Typescript Wallet SDK - 3.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary

Patch release rolling up the two correctness PRs landed since 3.0.0:

- **#237** — SEP-10: verify the auth server returns the same challenge body after `client_domain` re-signing instead of trusting a server-supplied transaction
- **#238** — three independent correctness fixes:
  - `submitWithFeeIncrease`: forward `maxFee` across recursive retries so the cap is enforced on every retry, not just the first
  - `submitTransaction`: replace unbounded recursive 504 retries with a bounded equal-jitter exponential backoff loop
  - `KeyManager.removeKey`: actually delete the in-memory cache entry instead of leaving it stale

No public API changes. No new dependencies. SemVer patch.

## Test plan

- [x] `yarn build` — all 3 packages compile successfully
- [x] `yarn lint` — zero warnings
- [x] `yarn test:ci` — all suites passing on `main` post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)