### PR TITLE
Release/3.0.2

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK Key Manager - 3.0.2
+* Version bump
+
 # Release notes - Typescript Wallet SDK Key Manager - 3.0.1
 
 ### Fixed

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,9 @@
+# Release notes - Typescript Wallet SDK Soroban - 3.0.2
+
+### Added
+* `getInvocationDetails` now walks the authorization tree to arbitrary depth (depth-first), so operations nested below the immediate sub-invocations are included in the returned list (#241)
+* `getInvocationArgs` now decodes the `CreateContractV2` host function, surfacing its constructor arguments via a new optional `constructorArgs` field on `FnArgsCreateWasm` and `FnArgsCreateSac` (#241)
+
 # Release notes - Typescript Wallet SDK Soroban - 3.0.1
 * Version bump
 

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK - 3.0.2
+* Version bump
+
 # Release notes - Typescript Wallet SDK - 3.0.1
 
 ### Fixed

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary

Patch release rolling up the change landed since 3.0.1:

- **#241** — `@stellar/typescript-wallet-sdk-soroban`: `getInvocationDetails` now walks the authorization tree to arbitrary depth (it previously stopped at the immediate sub-invocations), and `getInvocationArgs` decodes the `CreateContractV2` host function, surfacing its constructor arguments via a new optional `constructorArgs` field on `FnArgsCreateWasm` and `FnArgsCreateSac`.

The core SDK and key-manager packages have no shipped code changes since 3.0.1 (test-infra and CI only); they are version-bumped to keep the three packages in lockstep. The `getInvocationDetails` return type is unchanged (`InvocationArgs[]`) and `constructorArgs` is additive and optional, so there are no breaking API changes. No new dependencies. SemVer patch.

## Test plan

- [x] `yarn build` — all 3 packages compile successfully
- [x] `yarn lint` — zero warnings
- [x] `yarn test:ci` — all suites passing on `main` post-merge (255 passed, 5 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
