### PR TITLE
Validate SEP-7 origin_domain as a fully qualified domain name

### DIFF
--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/sep7.ts
@@ -18,3 +18,25 @@ export type IsValidSep7UriResult = {
   result: boolean;
   reason?: string;
 };
+
+/**
+ * Matches a fully qualified domain name (e.g. "example.com", "sub.example.co.uk").
+ *
+ * Rejects userinfo ('@'), ports (':'), paths/queries ('/', '?'), scheme
+ * prefixes ('//'), bare hostnames like 'localhost', and raw IPv4/IPv6
+ * addresses (the all-numeric final label fails the alphabetic TLD rule).
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md#verifying-the-signature step 3.
+ */
+export const FULLY_QUALIFIED_DOMAIN_NAME_REGEX =
+  /^(?=.{1,253}$)([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
+
+/**
+ * Returns true if the given string is a valid fully qualified domain name.
+ *
+ * @param {string} domain the domain string to validate.
+ *
+ * @returns {boolean} true if 'domain' is a valid fully qualified domain name.
+ */
+export const isValidFullyQualifiedDomainName = (domain: string): boolean =>
+  FULLY_QUALIFIED_DOMAIN_NAME_REGEX.test(domain);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/Sep7Base.ts
@@ -1,5 +1,9 @@
 import { Keypair, Networks, StellarToml } from "@stellar/stellar-sdk";
-import { Sep7OperationType, URI_MSG_MAX_LENGTH } from "../Types";
+import {
+  Sep7OperationType,
+  URI_MSG_MAX_LENGTH,
+  isValidFullyQualifiedDomainName,
+} from "../Types";
 import { Sep7LongMsgError } from "../Exceptions";
 
 /**
@@ -231,6 +235,15 @@ export abstract class Sep7Base {
 
     // we can fail fast if neither of them are set since we can't verify without both
     if (!originDomain || !signature) {
+      return false;
+    }
+
+    // SEP-7 step 3: "If the origin_domain is not a valid fully qualified
+    // domain name, do not allow the user to sign the transaction." This must
+    // be enforced before resolving the stellar.toml, otherwise a malformed
+    // origin_domain (e.g. containing userinfo, a port, or a path) could
+    // redirect the trust-anchoring TOML fetch to an attacker-controlled host.
+    if (!isValidFullyQualifiedDomainName(originDomain)) {
       return false;
     }
 

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Uri/sep7Parser.ts
@@ -8,6 +8,7 @@ import {
   WEB_STELLAR_SCHEME,
   URI_MSG_MAX_LENGTH,
   URI_REPLACE_MAX_LENGTH,
+  isValidFullyQualifiedDomainName,
 } from "../Types";
 import {
   Sep7InvalidUriError,
@@ -42,6 +43,7 @@ export const isValidSep7Uri = (uri: string): IsValidSep7UriResult => {
     url.searchParams.get("network_passphrase") || Networks.PUBLIC;
   const destination = url.searchParams.get("destination");
   const msg = url.searchParams.get("msg");
+  const originDomain = url.searchParams.get("origin_domain");
 
   if (![Sep7OperationType.tx, Sep7OperationType.pay].includes(type)) {
     return {
@@ -95,6 +97,18 @@ export const isValidSep7Uri = (uri: string): IsValidSep7UriResult => {
     return {
       result: false,
       reason: `the 'msg' parameter should be no longer than ${URI_MSG_MAX_LENGTH} characters`,
+    };
+  }
+
+  // 'origin_domain' is optional (SEP-7), but when present it must be a valid
+  // fully qualified domain name (SEP-7 step 3), otherwise a malformed value
+  // could later redirect the trust-anchoring stellar.toml fetch in
+  // Sep7Base.verifySignature() to an attacker-controlled host.
+  if (originDomain && !isValidFullyQualifiedDomainName(originDomain)) {
+    return {
+      result: false,
+      reason:
+        "the provided 'origin_domain' parameter is not a valid fully qualified domain name",
     };
   }
 

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -316,6 +316,25 @@ describe("Sep7Base", () => {
     expect(await uri.verifySignature()).toBe(false);
     expect(resolveSpy).not.toHaveBeenCalled();
   });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain has an injected CRLF", async () => {
+    // 'stellar.org%0d%0aevil.com' URL-decodes to 'stellar.org\r\nevil.com'.
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=stellar.org%0d%0aevil.com&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("Sep7Tx", () => {

--- a/@stellar/typescript-wallet-sdk/test/sep7.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/sep7.test.ts
@@ -226,6 +226,96 @@ describe("Sep7Base", () => {
 
     expect(await uri.verifySignature()).toBe(true);
   });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain has userinfo (RFC 3986 confusion)", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=stellar.org%40evil.com&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain has a port", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=example.com%3A8443&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain has a path", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=example.com%2Fpath&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain is a raw IPv4 address", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=127.0.0.1&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
+
+  it("verifySignature() returns false and never resolves the toml when origin_domain is 'localhost'", async () => {
+    const uriStr =
+      "web+stellar:tx?xdr=test&origin_domain=localhost&signature=sig";
+    const uri = new Sep7Tx(uriStr);
+
+    const resolveSpy = jest
+      .spyOn(StellarToml.Resolver, "resolve")
+      .mockResolvedValue({
+        URI_REQUEST_SIGNING_KEY: testKp1.publicKey,
+      });
+    // jest.spyOn() re-spying on an already-mocked function preserves the
+    // existing call history, so clear it to accurately assert non-invocation.
+    resolveSpy.mockClear();
+
+    expect(await uri.verifySignature()).toBe(false);
+    expect(resolveSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe("Sep7Tx", () => {
@@ -589,6 +679,32 @@ describe("sep7Parser", () => {
     ).toBe(true);
   });
 
+  it("isValidSep7Uri(uri) returns true when 'origin_domain' is absent", () => {
+    expect(
+      isValidSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens",
+      ).result,
+    ).toBe(true);
+  });
+
+  it("isValidSep7Uri(uri) returns true when 'origin_domain' is a valid fully qualified domain name", () => {
+    expect(
+      isValidSep7Uri(
+        "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=someDomain.com",
+      ).result,
+    ).toBe(true);
+  });
+
+  it("isValidSep7Uri(uri) returns 'false' with 'reason' when 'origin_domain' is not a valid fully qualified domain name", () => {
+    const validation = isValidSep7Uri(
+      "web+stellar:pay?destination=GCALNQQBXAPZ2WIRSDDBMSTAKCUH5SG6U76YBFLQLIXJTF7FE5AX7AOO&amount=120.1234567&memo=skdjfasf&msg=pay%20me%20with%20lumens&origin_domain=stellar.org%40evil.com",
+    );
+    expect(validation.result).toBe(false);
+    expect(validation.reason).toBe(
+      "the provided 'origin_domain' parameter is not a valid fully qualified domain name",
+    );
+  });
+
   it("isValidSep7Uri(uri) returns 'false' with 'reason' when it is not valid in some way", () => {
     const validation1 = isValidSep7Uri(
       "not-a-stellar-uri:tx?xdr=AAAAAP%2Byw%2BZEuNg533pUmwlYxfrq6%2FBoMJqiJ8vuQhf6rHWmAAAAZAB8NHAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAYAAAABSFVHAAAAAABAH0wIyY3BJBS2qHdRPAV80M8hF7NBpxRjXyjuT9kEbH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FAAAAAAAAAAA%3D&callback=url%3Ahttps%3A%2F%2FsomeSigningService.com%2Fa8f7asdfkjha&pubkey=GAU2ZSYYEYO5S5ZQSMMUENJ2TANY4FPXYGGIMU6GMGKTNVDG5QYFW6JS&msg=order%20number%2024",
@@ -834,7 +950,9 @@ describe("sep7Parser", () => {
 
   it("Sep7Tx.getReplacements() throws on replace param missing hints", () => {
     const uri = new Sep7Tx(
-      `web+stellar:tx?xdr=test&replace=${encodeURIComponent("sourceAccount:X")}`,
+      `web+stellar:tx?xdr=test&replace=${encodeURIComponent(
+        "sourceAccount:X",
+      )}`,
     );
 
     expect(() => uri.getReplacements()).toThrow(Sep7InvalidUriError);


### PR DESCRIPTION
## Summary

Fixes a signature-verification bypass in SEP-7 (`web+stellar:`) request handling caused by a missing validation of the request's origin domain.

## The vulnerability

When a wallet verifies a signed SEP-7 request, it looks up the requesting domain's `stellar.toml` to obtain that domain's request-signing key and confirm the request's signature against it. A successful result is the signal wallets use to tell the user the request is genuinely from that domain.

The origin domain was taken directly from the incoming request and used to build that lookup with no validation. Because the value lands in the host portion of the lookup URL, a crafted origin domain could send the lookup somewhere other than the real domain:

- Using the `trusted-domain@attacker-host` URL form, the lookup is actually made to the attacker's host while the value still reads as starting with a trusted domain.
- A port, path, query string, or raw IP address could likewise redirect or retarget the lookup.

An attacker could therefore host their own signing key, sign a malicious payment or transaction request with it, and have verification report success — presenting an attacker-controlled request as a verified request from a domain the user trusts. SEP-7 explicitly requires the origin domain to be validated as a fully qualified domain name before this lookup happens; that step was not implemented.

## The fix

- The origin domain is now validated as a bare fully qualified domain name before it is used. Values carrying embedded credentials, ports, paths, query strings, scheme prefixes, bare hostnames such as `localhost`, or raw IP addresses are rejected.
- Validation is enforced at the security boundary: signature verification now fails fast for an invalid origin domain, before any network lookup is attempted. The same check is also applied when a request is parsed, as defense in depth.
- The origin domain remains optional, and all existing public interfaces keep their current shapes and behavior — this change only adds a new, additive validation helper.
- Added tests covering the spoofing vectors (embedded credentials, ports, paths, IP addresses, `localhost`, and CR/LF injection) that assert the `stellar.toml` lookup is never performed for an invalid origin domain, alongside the existing valid-domain cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhKQtqCSXvx3i7sxq1eDJ8

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhKQtqCSXvx3i7sxq1eDJ8)_