### PR TITLE
Verify SEP-10 challenge body integrity after domain signing in key manager

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/src/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/Exceptions/index.ts
@@ -1,0 +1,8 @@
+export class DomainSigningModifiedError extends Error {
+  constructor() {
+    super(
+      "Domain signer returned a transaction whose body differs from the original challenge. Only the client_domain signature should be added.",
+    );
+    Object.setPrototypeOf(this, DomainSigningModifiedError.prototype);
+  }
+}

--- a/@stellar/typescript-wallet-sdk-km/src/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/Exceptions/index.ts
@@ -1,8 +1,9 @@
 export class DomainSigningModifiedError extends Error {
   constructor() {
     super(
-      "Domain signer returned a transaction whose body differs from the original challenge. Only the client_domain signature should be added.",
+      "Domain signer returned a transaction that differs from the original challenge. Only the client_domain signature should be added — the operations, source account, sequence number, memo and network passphrase must all be left unchanged.",
     );
+    this.name = "DomainSigningModifiedError";
     Object.setPrototypeOf(this, DomainSigningModifiedError.prototype);
   }
 }

--- a/@stellar/typescript-wallet-sdk-km/src/index.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./keyManager";
+export * from "./Exceptions";
 export * from "./Handlers";
 export * from "./Plugins";
 export * from "./Helpers";

--- a/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
@@ -246,8 +246,11 @@ export class KeyManager {
    * `params.clientDomain` is set, you need to provide a function that will add
    * the signature identified by the SIGNING_KEY present on your client domain's
    * toml file. The callback may only append signatures: the returned
-   * transaction's body hash is compared against the validated challenge and a
-   * `DomainSigningModifiedError` is thrown if they differ.
+   * transaction's hash is compared against the validated challenge and a
+   * `DomainSigningModifiedError` is thrown if they differ. That hash covers
+   * the operations, source account, sequence number, memo and network
+   * passphrase, but not the signatures, so appending a signature is the only
+   * change the callback can make.
    * @param {string} [params.account] The authenticating public key. If not
    * provided, then the signers's public key will be used instead.
    * @returns {Promise<string>} authToken JWT.

--- a/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
+++ b/@stellar/typescript-wallet-sdk-km/src/keyManager.ts
@@ -1,5 +1,6 @@
 import { Networks, Transaction, WebAuth } from "@stellar/stellar-sdk";
 
+import { DomainSigningModifiedError } from "./Exceptions";
 import { freighterHandler } from "./Handlers/freighter";
 import { albedoHandler } from "./Handlers/albedo";
 import { ledgerHandler } from "./Handlers/ledger";
@@ -244,7 +245,9 @@ export class KeyManager {
    * @param {Function} params.onChallengeTransactionSignature When
    * `params.clientDomain` is set, you need to provide a function that will add
    * the signature identified by the SIGNING_KEY present on your client domain's
-   * toml file.
+   * toml file. The callback may only append signatures: the returned
+   * transaction's body hash is compared against the validated challenge and a
+   * `DomainSigningModifiedError` is thrown if they differ.
    * @param {string} [params.account] The authenticating public key. If not
    * provided, then the signers's public key will be used instead.
    * @returns {Promise<string>} authToken JWT.
@@ -362,9 +365,22 @@ export class KeyManager {
       new URL(authServer).hostname,
     ).tx;
 
+    const originalHash = transaction.hash();
+
     // Add extra signatures.
     // By default, the input transaction is returned as it is.
-    transaction = await onChallengeTransactionSignature(transaction);
+    const returned = await onChallengeTransactionSignature(transaction);
+
+    // Transaction.hash() covers the envelope body and the network passphrase but
+    // excludes signatures, so a callback that only appends the client_domain
+    // signature preserves the hash. Any change to the operations, source
+    // account, sequence number, memo or network changes the hash and is
+    // rejected here, so the validated challenge is what actually gets signed.
+    if (!returned.hash().equals(originalHash)) {
+      throw new DomainSigningModifiedError();
+    }
+
+    transaction = returned;
 
     const keyHandler = this.keyHandlerMap[key.type];
 

--- a/@stellar/typescript-wallet-sdk-km/test/keyManager.test.ts
+++ b/@stellar/typescript-wallet-sdk-km/test/keyManager.test.ts
@@ -3,6 +3,7 @@ import {
   Networks,
   Keypair,
   Account,
+  Asset,
   TransactionBuilder,
   Operation,
   Transaction,
@@ -18,6 +19,7 @@ import randomBytes from "randombytes";
 import sinon from "sinon";
 
 import { KeyManager } from "../src";
+import { DomainSigningModifiedError } from "../src/Exceptions";
 import { KeyType } from "../src/Types";
 import {
   MemoryKeyStore,
@@ -777,6 +779,195 @@ describe("fetchAuthToken", () => {
 
     expect(verified).toBeTruthy();
     expect(res).toBe(token);
+  });
+
+  test("Rejects challenge signature callbacks that alter the body", async () => {
+    const authServer = "https://www.stellar.org/auth";
+    const password = "very secure password";
+
+    const keyNetwork = Networks.TESTNET;
+
+    const accountKey = Keypair.random();
+    const account = new Account(accountKey.publicKey(), "-1");
+
+    // set up the manager
+    const testStore = new MemoryKeyStore();
+    const testKeyManager = new KeyManager({
+      keyStore: testStore,
+    });
+
+    testKeyManager.registerEncrypter(IdentityEncrypter);
+
+    const keypair = Keypair.master(keyNetwork);
+
+    const value = randomBytes(48).toString("base64");
+
+    const tx = new TransactionBuilder(account, {
+      fee: BASE_FEE,
+      networkPassphrase: keyNetwork,
+    })
+      .addOperation(
+        Operation.manageData({
+          name: `stellar.org auth`,
+          value,
+          source: keypair.publicKey(),
+        }),
+      )
+      .addOperation(
+        Operation.manageData({
+          name: "web_auth_domain",
+          value: new URL(authServer).hostname,
+          source: account.accountId(),
+        }),
+      )
+      .setTimeout(300)
+      .build();
+
+    tx.sign(accountKey);
+
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          transaction: tx.toXDR(),
+          network_passphrase: keyNetwork,
+        }),
+      ),
+    );
+
+    const keyMetadata = await testKeyManager.storeKey({
+      key: {
+        type: KeyType.plaintextKey,
+        publicKey: keypair.publicKey(),
+        privateKey: keypair.secret(),
+        network: keyNetwork,
+      },
+      password,
+      encrypterName: "IdentityEncrypter",
+    });
+
+    // A callback in the client domain signer's position that returns an
+    // entirely different, submittable transaction instead of appending its
+    // signature to the challenge it was given.
+    const substituted = new TransactionBuilder(
+      new Account(keypair.publicKey(), "1"),
+      {
+        fee: BASE_FEE,
+        networkPassphrase: keyNetwork,
+      },
+    )
+      .addOperation(
+        Operation.payment({
+          destination: Keypair.random().publicKey(),
+          asset: Asset.native(),
+          amount: "100",
+        }),
+      )
+      .setTimeout(300)
+      .build();
+
+    await expect(
+      testKeyManager.fetchAuthToken({
+        id: keyMetadata.id,
+        password,
+        authServer,
+        authServerKey: account.accountId(),
+        authServerHomeDomains: ["stellar.org"],
+        onChallengeTransactionSignature: () => Promise.resolve(substituted),
+      }),
+    ).rejects.toThrow(DomainSigningModifiedError);
+
+    // The challenge was fetched, but nothing was signed or posted back.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(substituted.signatures.length).toEqual(0);
+  });
+
+  test("Rejects challenge signature callbacks that alter the network", async () => {
+    const authServer = "https://www.stellar.org/auth";
+    const password = "very secure password";
+
+    const keyNetwork = Networks.TESTNET;
+
+    const accountKey = Keypair.random();
+    const account = new Account(accountKey.publicKey(), "-1");
+
+    // set up the manager
+    const testStore = new MemoryKeyStore();
+    const testKeyManager = new KeyManager({
+      keyStore: testStore,
+    });
+
+    testKeyManager.registerEncrypter(IdentityEncrypter);
+
+    const keypair = Keypair.master(keyNetwork);
+
+    const value = randomBytes(48).toString("base64");
+
+    const buildChallenge = (networkPassphrase: string) => {
+      const challenge = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase,
+      })
+        .addOperation(
+          Operation.manageData({
+            name: `stellar.org auth`,
+            value,
+            source: keypair.publicKey(),
+          }),
+        )
+        .addOperation(
+          Operation.manageData({
+            name: "web_auth_domain",
+            value: new URL(authServer).hostname,
+            source: account.accountId(),
+          }),
+        )
+        .setTimeout(300)
+        .build();
+
+      challenge.sign(accountKey);
+
+      return challenge;
+    };
+
+    const tx = buildChallenge(keyNetwork);
+
+    // Same body, different network. The signing hash is derived from the
+    // returned transaction's own passphrase, so without the guard a key
+    // registered for TESTNET would produce a PUBLIC-valid signature.
+    const otherNetworkTx = buildChallenge(Networks.PUBLIC);
+
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          transaction: tx.toXDR(),
+          network_passphrase: keyNetwork,
+        }),
+      ),
+    );
+
+    const keyMetadata = await testKeyManager.storeKey({
+      key: {
+        type: KeyType.plaintextKey,
+        publicKey: keypair.publicKey(),
+        privateKey: keypair.secret(),
+        network: keyNetwork,
+      },
+      password,
+      encrypterName: "IdentityEncrypter",
+    });
+
+    await expect(
+      testKeyManager.fetchAuthToken({
+        id: keyMetadata.id,
+        password,
+        authServer,
+        authServerKey: account.accountId(),
+        authServerHomeDomains: ["stellar.org"],
+        onChallengeTransactionSignature: () => Promise.resolve(otherNetworkTx),
+      }),
+    ).rejects.toThrow(DomainSigningModifiedError);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   test("Can use a challenge token", async () => {


### PR DESCRIPTION
Mirrors the hardening from https://github.com/stellar/typescript-wallet-sdk/pull/237 in the key manager package.

`KeyManager.fetchAuthToken` validates the SEP-10 challenge with `WebAuth.readChallengeTx`, then assigns the `onChallengeTransactionSignature` callback's return value back over the validated transaction and signs it as-is — so what gets signed isn't necessarily what was validated. The callback's documented contract is to append the client domain signature and nothing else; this enforces it:

```ts
const originalHash = transaction.hash();

const returned = await onChallengeTransactionSignature(transaction);

if (!returned.hash().equals(originalHash)) {
  throw new DomainSigningModifiedError();
}

transaction = returned;
```

`hash()` covers the envelope body but excludes signatures, so append-only callbacks pass unchanged. It also covers the network passphrase, which `plaintextKeyHandler` uses to derive the signing hash — so the same comparison keeps a key registered for one network from signing for another. The check is unconditional; the default callback is the identity function, so it costs one hash and can't regress existing callers.

The package had no exceptions module, so this adds one and exports `DomainSigningModifiedError` from the package root, matching the core SDK.

## Testing

Two regression tests, both verified to fail with the guard removed:
- callback returns a different, submittable transaction body
- callback returns the same body built for a different network

The existing `Sets additional signature` test covers the append-only path and still passes.

`yarn lint` clean · `yarn test:ci` 16 suites / 257 tests passed · km build compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)