### PR TITLE
Release/3.0.3

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,11 @@
+# Release notes - Typescript Wallet SDK Key Manager - 3.0.3
+
+### Fixed
+* Verify SEP-10 challenge body integrity after domain signing in key manager (#245)
+
+### Added
+* `DomainSigningModifiedError`, exported from the package root (#245)
+
 # Release notes - Typescript Wallet SDK Key Manager - 3.0.2
 * Version bump
 

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK Soroban - 3.0.3
+* Version bump
+
 # Release notes - Typescript Wallet SDK Soroban - 3.0.2
 
 ### Added

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "engines": {
     "node": ">=20"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,11 @@
+# Release notes - Typescript Wallet SDK - 3.0.3
+
+### Fixed
+* Validate SEP-7 origin_domain as a fully qualified domain name (#244)
+
+### Added
+* `Types.isValidFullyQualifiedDomainName` and `Types.FULLY_QUALIFIED_DOMAIN_NAME_REGEX` (#244)
+
 # Release notes - Typescript Wallet SDK - 3.0.2
 * Version bump
 

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
Bumps all three packages to `3.0.3` and updates their changelogs.

* Validate SEP-7 origin_domain as a fully qualified domain name (#244)
* Verify SEP-10 challenge body integrity after domain signing in key manager (#245)

`@stellar/typescript-wallet-sdk-soroban` has no shipped changes since 3.0.2 and is bumped to stay in lockstep, matching #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)