### PR TITLE
fix: keep eventsource from breaking imports on React Native

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk-km/webpack.config.js
@@ -19,6 +19,14 @@ module.exports = (env = { NODE: false }) => {
     },
     resolve: {
       extensions: [".js", ".json", ".ts"],
+      alias: {
+        // stellar-sdk's root entry eagerly loads Horizon's CallBuilder, which
+        // requires eventsource v4. That module subclasses the DOM globals Event
+        // and EventTarget at module scope, so importing this package threw
+        // "Property 'Event' doesn't exist" on React Native (Hermes has neither).
+        // Horizon is unreachable from this package's API, so stub it out.
+        eventsource: false,
+      },
       fallback: isBrowser
         ? {
             crypto: require.resolve("crypto-browserify"),

--- a/@stellar/typescript-wallet-sdk-soroban/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk-soroban/webpack.config.js
@@ -19,6 +19,14 @@ module.exports = (env = { NODE: false }) => {
     },
     resolve: {
       extensions: [".js", ".json", ".ts"],
+      alias: {
+        // stellar-sdk's root entry eagerly loads Horizon's CallBuilder, which
+        // requires eventsource v4. That module subclasses the DOM globals Event
+        // and EventTarget at module scope, so importing this package threw
+        // "Property 'Event' doesn't exist" on React Native (Hermes has neither).
+        // Horizon is unreachable from this package's API, so stub it out.
+        eventsource: false,
+      },
       fallback: isBrowser
         ? {
             crypto: require.resolve("crypto-browserify"),

--- a/@stellar/typescript-wallet-sdk/src/shims/eventsource.js
+++ b/@stellar/typescript-wallet-sdk/src/shims/eventsource.js
@@ -14,8 +14,19 @@ let realModule;
 
 const load = () => {
   if (!realModule) {
-    // eslint-disable-next-line global-require
-    realModule = require("eventsource-real");
+    try {
+      // eslint-disable-next-line global-require
+      realModule = require("eventsource-real");
+    } catch (cause) {
+      // CallBuilder.stream() catches this and retries on a timer, so make the
+      // error it reports to onerror self-explanatory.
+      throw new Error(
+        "Horizon streaming needs the DOM Event/EventTarget globals and a " +
+          "streaming fetch body, which React Native does not provide. Alias " +
+          '"eventsource" to a native SSE client (e.g. react-native-sse) to use ' +
+          `CallBuilder.stream(). Original error: ${cause.message}`,
+      );
+    }
   }
 
   return realModule;

--- a/@stellar/typescript-wallet-sdk/src/shims/eventsource.js
+++ b/@stellar/typescript-wallet-sdk/src/shims/eventsource.js
@@ -1,0 +1,34 @@
+/**
+ * Lazy `eventsource` facade.
+ *
+ * eventsource v4 subclasses the DOM globals `Event`/`EventTarget` at module
+ * scope, which React Native's Hermes does not provide. Horizon's CallBuilder
+ * requires this module eagerly but only reads it inside `stream()`, so deferring
+ * evaluation to first property access keeps imports working everywhere while
+ * leaving streaming intact wherever those globals exist.
+ *
+ * Aliased in webpack.config.js: `eventsource$` resolves here, `eventsource-real$`
+ * to the real package.
+ */
+let realModule;
+
+const load = () => {
+  if (!realModule) {
+    // eslint-disable-next-line global-require
+    realModule = require("eventsource-real");
+  }
+
+  return realModule;
+};
+
+Object.defineProperty(exports, "EventSource", {
+  enumerable: true,
+  configurable: true,
+  get: () => load().EventSource,
+});
+
+Object.defineProperty(exports, "ErrorEvent", {
+  enumerable: true,
+  configurable: true,
+  get: () => load().ErrorEvent,
+});

--- a/@stellar/typescript-wallet-sdk/webpack.config.js
+++ b/@stellar/typescript-wallet-sdk/webpack.config.js
@@ -19,6 +19,17 @@ module.exports = (env = { NODE: false }) => {
     },
     resolve: {
       extensions: [".js", ".json", ".ts"],
+      alias: {
+        // eventsource v4, reached via stellar-sdk's Horizon CallBuilder,
+        // subclasses the DOM globals Event and EventTarget at module scope, so
+        // importing this package threw "Property 'Event' doesn't exist" on React
+        // Native. Unlike the km and soroban packages, this one exposes
+        // Horizon.Server publicly, so stubbing eventsource out would break
+        // .stream() on web and Node. Defer its evaluation to first use instead.
+        eventsource$: path.resolve(__dirname, "src/shims/eventsource.js"),
+        // The facade's load target; "eventsource" would resolve back to itself.
+        "eventsource-real$": require.resolve("eventsource"),
+      },
       fallback: isBrowser
         ? {
             crypto: require.resolve("crypto-browserify"),


### PR DESCRIPTION
## Problem

`eventsource` v4 — pulled in by stellar-sdk 16 through Horizon's `CallBuilder` — subclasses the DOM globals `Event` and `EventTarget` at module scope. Hermes provides neither, and because webpack emits its `__webpack_require__` calls ahead of time, Metro's `inlineRequires` cannot defer them the way it defers a plain `require("eventsource")`. Importing any of the three bundles crashed React Native apps with `Property 'Event' doesn't exist`.

## Change

- **km / soroban** — `eventsource: false`. Neither package touches Horizon nor re-exports the SDK, so `EventSource` is not reachable through their public APIs and the module is dead weight in those bundles.
- **main** — this package does expose `Horizon.Server` publicly (`StellarConfiguration.server`), so stubbing eventsource out would break `.stream()` for web and Node consumers. It routes eventsource through a small lazy facade instead: imports work everywhere, and `.stream()` keeps working wherever the DOM event globals exist.

## Note for React Native consumers

None of these packages call `.stream()` themselves — there are no `.stream()` calls or `EventSource` references anywhere in their source, and the main package's `Watcher` polls with `setTimeout`. The facade exists purely for consumers reaching Horizon streaming through the exposed `Horizon.Server`. So if your app does not call `.stream()` through that export, it should keep working with no issues after the v16 upgrade plus this PR.

If you do need Horizon streaming, the facade fixes importing, not streaming. `CallBuilder.stream()` wraps `new EventSource()` in a try/catch and schedules a reconnect regardless, so on Hermes the failure is **reported through your `onerror` callback and retried every 15s** (`reconnectTimeout`) — not thrown to the caller, and swallowed silently if you pass no `onerror`. The facade wraps that failure so the reported error names the cause and the fix. Making streaming actually work needs more than `Event`/`EventTarget`: eventsource v4 also requires `MessageEvent`, `TextDecoder`, and a streaming `response.body.getReader()`, which React Native's XHR-backed fetch does not provide. Those apps must supply their own transport — e.g. aliasing `eventsource` to `react-native-sse` in Metro.

## Verification

Built all three packages and loaded both bundles with the DOM event globals deleted (Hermes-like) and present (web/Node baseline): all six import cleanly, main's `.stream()` still constructs a real `EventSource`, and km's store → encrypt → decrypt round-trip passes with a wrong password rejected. Reverting the configs reproduces the failure, with the stack pointing at the bundled eventsource module.

Also verified end to end in a React Native app (Freighter mobile) on **both iOS and Android**, using published betas of all three packages: each one imports and is usable on Hermes — a `Wallet` plus generated keypair from the main SDK, the soroban token-amount helpers, and a full key store → encrypt → load → decrypt round-trip through the key manager with a wrong password rejected. The app had no `Event`/`EventTarget` polyfill of its own, so the bundle fix is carrying this unaided.

The existing suite passes (`yarn test:ci`, 274 tests). Worth noting it imports from `src/` rather than the built bundles, so it does not exercise these webpack aliases — the bundle checks above are what cover this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
