### PR TITLE
Release/4.0.0

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,9 @@
+# Release notes - Typescript Wallet SDK Key Manager - 4.0.0
+
+### BREAKING CHANGES
+* Upgraded `@stellar/stellar-sdk` from `15.0.1` to `16.2.0` (#243)
+* Minimum Node.js version raised from 20 to 22, as required by stellar-sdk v16 (#243)
+
 # Release notes - Typescript Wallet SDK Key Manager - 3.0.3
 
 ### Fixed

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "engines": {
     "node": ">=22"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,9 @@
+# Release notes - Typescript Wallet SDK Soroban - 4.0.0
+
+### BREAKING CHANGES
+* Upgraded `@stellar/stellar-sdk` from `15.0.1` to `16.2.0` (#243)
+* Minimum Node.js version raised from 20 to 22, as required by stellar-sdk v16 (#243)
+
 # Release notes - Typescript Wallet SDK Soroban - 3.0.3
 * Version bump
 

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "engines": {
     "node": ">=22"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,14 @@
+# Release notes - Typescript Wallet SDK - 4.0.0
+
+### BREAKING CHANGES
+* Upgraded `@stellar/stellar-sdk` from `15.0.1` to `16.2.0` (#243)
+* Minimum Node.js version raised from 20 to 22, as required by stellar-sdk v16 (#243)
+
+### Changed
+* `AccountService.getHistory` no longer sends an empty paging cursor. stellar-sdk v16 serializes query params via `URLSearchParams`, so an undefined cursor was sent as the literal `cursor=undefined` and Horizon returned a 400 (#243)
+* Withdrawal transactions now map malformed anchor-supplied memos to `WithdrawalTxMemoError` for every memo type (not just `hash`), matching v16's stricter `Memo` validation on untrusted input (#243)
+* Internal source-account typing now uses stellar-sdk v16's `TransactionSource` interface (#243)
+
 # Release notes - Typescript Wallet SDK - 3.0.3
 
 ### Fixed

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "3.0.3",
+  "version": "4.0.0",
   "engines": {
     "node": ">=22"
   },


### PR DESCRIPTION
## Summary

Major release shipping the **`@stellar/stellar-sdk` v16 upgrade** ([#243](https://github.com/stellar/typescript-wallet-sdk/pull/243) + [#248](https://github.com/stellar/typescript-wallet-sdk/pull/248)) across all three packages. Version bumped **3.0.3 → 4.0.0** in lockstep (core, key-manager, soroban).

### Why 4.0.0 (breaking changes for consumers)

- **Node.js 22+ is now required** (raised from 20) — mandated by stellar-sdk v16.
- **`@stellar/stellar-sdk` 15.0.1 → 16.2.0** — v16 is itself a major release (fetch replaces axios, stricter input validation, ESM-first packaging, Protocol 27). Consumers who rely on our re-exported stellar-sdk types or on axios-based HTTP behavior may be affected.

Both warrant a major bump, hence 4.0.0.

### What's in it

The v16 adaptation work already merged in #243; there are no consumer-facing API changes beyond the environment/SDK bump above. Internally: `getHistory` cursor handling, withdrawal-memo error mapping to `WithdrawalTxMemoError`, and `TransactionSource` typing. See each package's `CHANGELOG.MD` for the details.

## Test plan

- [x] `yarn build` — all 3 packages compile
- [x] `yarn lint` — zero warnings
- [x] `yarn test:ci` — 274 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)