### PR TITLE
Release/4.0.1 — improve challenge tx validation in Server helper

### DIFF
--- a/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-km/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK Key Manager - 4.0.1
+* Version bump
+
 # Release notes - Typescript Wallet SDK Key Manager - 4.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk-km/package.json
+++ b/@stellar/typescript-wallet-sdk-km/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-km",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "engines": {
     "node": ">=22"
   },

--- a/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk-soroban/CHANGELOG.MD
@@ -1,3 +1,6 @@
+# Release notes - Typescript Wallet SDK Soroban - 4.0.1
+* Version bump
+
 # Release notes - Typescript Wallet SDK Soroban - 4.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk-soroban/package.json
+++ b/@stellar/typescript-wallet-sdk-soroban/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk-soroban",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "engines": {
     "node": ">=22"
   },

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -8,6 +8,9 @@
 * Optional `homeDomain` on `SignChallengeTxnParams`, accepting a string or an array of strings for anchors serving multiple home domains. Defaults to `anchorDomain` (#250)
 * `ChallengeTxnClientAccountMismatchError`, exported via `Exceptions` (#250)
 
+### Deprecated
+* `ChallengeTxnInvalidSignatureError` is no longer thrown and will be removed in the next major release. Catch `ChallengeValidationFailedError` instead (#250)
+
 # Release notes - Typescript Wallet SDK - 4.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk/CHANGELOG.MD
+++ b/@stellar/typescript-wallet-sdk/CHANGELOG.MD
@@ -1,3 +1,13 @@
+# Release notes - Typescript Wallet SDK - 4.0.1
+
+### Changed
+* `Server.signChallengeTransaction`: validate the challenge with `WebAuth.readChallengeTx`, as `Sep10.sign` already does, and verify it was issued for `accountKp` before signing (#250)
+* `Server.signChallengeTransaction`: validation failures now throw `ChallengeValidationFailedError` instead of `ChallengeTxnInvalidSignatureError` (#250)
+
+### Added
+* Optional `homeDomain` on `SignChallengeTxnParams`, accepting a string or an array of strings for anchors serving multiple home domains. Defaults to `anchorDomain` (#250)
+* `ChallengeTxnClientAccountMismatchError`, exported via `Exceptions` (#250)
+
 # Release notes - Typescript Wallet SDK - 4.0.0
 
 ### BREAKING CHANGES

--- a/@stellar/typescript-wallet-sdk/package.json
+++ b/@stellar/typescript-wallet-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/typescript-wallet-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "engines": {
     "node": ">=22"
   },

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -312,6 +312,12 @@ export class ChallengeTxnIncorrectSequenceError extends Error {
   }
 }
 
+/**
+ * @deprecated No longer thrown. `Server.signChallengeTransaction` now validates
+ * challenges with `WebAuth.readChallengeTx` and reports every failure, including
+ * an invalid server signature, as `ChallengeValidationFailedError`. This class
+ * will be removed in the next major release.
+ */
 export class ChallengeTxnInvalidSignatureError extends Error {
   constructor() {
     super("Invalid signature for challenge transaction");

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts
@@ -319,6 +319,19 @@ export class ChallengeTxnInvalidSignatureError extends Error {
   }
 }
 
+export class ChallengeTxnClientAccountMismatchError extends Error {
+  constructor(expected: string, received: string) {
+    super(
+      `Challenge transaction client account mismatch: expected "${expected}" ` +
+        `but challenge was issued for "${received}"`,
+    );
+    Object.setPrototypeOf(
+      this,
+      ChallengeTxnClientAccountMismatchError.prototype,
+    );
+  }
+}
+
 export class AllowHttpOnNonTestnetError extends Error {
   constructor() {
     super("Can only allow Http on Testnet");

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
@@ -36,7 +36,8 @@ import {
  * checks the full SEP-10 structure and binds the challenge to the expected
  * anchor: the transaction source must be the anchor's `SIGNING_KEY`, the
  * `<home domain> auth` operation must match the expected home domain, and any
- * `web_auth_domain` operation must match the anchor's `WEB_AUTH_ENDPOINT`.
+ * `web_auth_domain` operation must match the host of the anchor's
+ * `WEB_AUTH_ENDPOINT` (falling back to `anchorDomain` when the TOML omits it).
  * The client account the challenge was issued for is then checked against
  * `accountKp`, so this helper only signs challenges meant for it. Muxed client
  * accounts are supported: the comparison is made on the underlying `G...`
@@ -71,13 +72,15 @@ export const signChallengeTransaction = async ({
   const tomlResp = await StellarToml.Resolver.resolve(anchorDomain);
   const { signingKey, webAuthEndpoint } = parseToml(tomlResp);
 
-  const webAuthDomain = webAuthEndpoint
-    ? new URL(webAuthEndpoint).hostname
-    : anchorDomain;
-
   let tx: Transaction;
   let clientAccountID: string;
   try {
+    // Kept inside the try so a malformed WEB_AUTH_ENDPOINT surfaces as a
+    // ChallengeValidationFailedError rather than a raw TypeError.
+    const webAuthDomain = webAuthEndpoint
+      ? new URL(webAuthEndpoint).hostname
+      : anchorDomain;
+
     ({ tx, clientAccountID } = WebAuth.readChallengeTx(
       challengeTx,
       signingKey,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
@@ -8,6 +8,7 @@ import {
   TransactionBuilder,
   StellarToml,
   WebAuth,
+  extractBaseAddress,
 } from "@stellar/stellar-sdk";
 
 import { parseToml } from "../Utils";
@@ -37,7 +38,11 @@ import {
  * `<home domain> auth` operation must match the expected home domain, and any
  * `web_auth_domain` operation must match the anchor's `WEB_AUTH_ENDPOINT`.
  * The client account the challenge was issued for is then checked against
- * `accountKp`, so this helper only signs challenges meant for it.
+ * `accountKp`, so this helper only signs challenges meant for it. Muxed client
+ * accounts are supported: the comparison is made on the underlying `G...`
+ * address, since that is the key that signs. The muxed id itself is not pinned
+ * — a caller that needs to bind a specific subaccount should check the
+ * challenge's client account itself.
  *
  * @param {SignChallengeTxnParams} params - The Authentication params.
  * @param {AccountKeypair} params.accountKp - Keypair for the Stellar account signing the transaction.
@@ -86,7 +91,10 @@ export const signChallengeTransaction = async ({
     );
   }
 
-  if (clientAccountID !== accountKp.publicKey) {
+  // readChallengeTx returns the operation source verbatim, which is an `M...`
+  // address for a muxed client account. accountKp.publicKey is always the
+  // underlying `G...` key, so compare base addresses.
+  if (extractBaseAddress(clientAccountID) !== accountKp.publicKey) {
     throw new ChallengeTxnClientAccountMismatchError(
       accountKp.publicKey,
       clientAccountID,

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts
@@ -6,8 +6,8 @@
 import {
   Transaction,
   TransactionBuilder,
-  Keypair,
   StellarToml,
+  WebAuth,
 } from "@stellar/stellar-sdk";
 
 import { parseToml } from "../Utils";
@@ -21,18 +21,30 @@ import {
 } from "../Types";
 import {
   ChallengeTxnIncorrectSequenceError,
-  ChallengeTxnInvalidSignatureError,
+  ChallengeTxnClientAccountMismatchError,
+  ChallengeValidationFailedError,
   UnknownAnchorTransactionError,
   InvalidJsonError,
 } from "../Exceptions";
 
 /**
  * Helper method for signing a SEP-10 challenge transaction if valid.
+ *
+ * The challenge is validated with `WebAuth.readChallengeTx` from
+ * `@stellar/stellar-sdk` — the same validator used by `Sep10.sign()` — which
+ * checks the full SEP-10 structure and binds the challenge to the expected
+ * anchor: the transaction source must be the anchor's `SIGNING_KEY`, the
+ * `<home domain> auth` operation must match the expected home domain, and any
+ * `web_auth_domain` operation must match the anchor's `WEB_AUTH_ENDPOINT`.
+ * The client account the challenge was issued for is then checked against
+ * `accountKp`, so this helper only signs challenges meant for it.
+ *
  * @param {SignChallengeTxnParams} params - The Authentication params.
  * @param {AccountKeypair} params.accountKp - Keypair for the Stellar account signing the transaction.
  * @param {string} [params.challengeTx] - The challenge transaction given by an anchor for authentication.
  * @param {string} [params.networkPassphrase] - The network passphrase for the network authenticating on.
  * @param {string} [params.anchorDomain] - Domain hosting stellar.toml file containing `SIGNING_KEY`.
+ * @param {string|string[]} [params.homeDomain] - Expected home domain(s) of the challenge. Defaults to `anchorDomain`.
  * @returns {Promise<SignChallengeTxnResponse>} The signed transaction.
  */
 export const signChallengeTransaction = async ({
@@ -40,25 +52,45 @@ export const signChallengeTransaction = async ({
   challengeTx,
   networkPassphrase,
   anchorDomain,
+  homeDomain,
 }: SignChallengeTxnParams): Promise<SignChallengeTxnResponse> => {
-  const tx = TransactionBuilder.fromXDR(
+  const parsedTx = TransactionBuilder.fromXDR(
     challengeTx,
     networkPassphrase,
   ) as Transaction;
 
-  if (parseInt(tx.sequence) !== 0) {
+  if (parseInt(parsedTx.sequence) !== 0) {
     throw new ChallengeTxnIncorrectSequenceError();
   }
 
   const tomlResp = await StellarToml.Resolver.resolve(anchorDomain);
-  const parsedToml = parseToml(tomlResp);
-  const anchorKp = Keypair.fromPublicKey(parsedToml.signingKey);
+  const { signingKey, webAuthEndpoint } = parseToml(tomlResp);
 
-  const isValid =
-    tx.signatures.length &&
-    anchorKp.verify(tx.hash(), tx.signatures[0].signature());
-  if (!isValid) {
-    throw new ChallengeTxnInvalidSignatureError();
+  const webAuthDomain = webAuthEndpoint
+    ? new URL(webAuthEndpoint).hostname
+    : anchorDomain;
+
+  let tx: Transaction;
+  let clientAccountID: string;
+  try {
+    ({ tx, clientAccountID } = WebAuth.readChallengeTx(
+      challengeTx,
+      signingKey,
+      networkPassphrase,
+      homeDomain ?? anchorDomain,
+      webAuthDomain,
+    ));
+  } catch (e) {
+    throw new ChallengeValidationFailedError(
+      e instanceof Error ? e : new Error(String(e)),
+    );
+  }
+
+  if (clientAccountID !== accountKp.publicKey) {
+    throw new ChallengeTxnClientAccountMismatchError(
+      accountKp.publicKey,
+      clientAccountID,
+    );
   }
 
   accountKp.sign(tx);

--- a/@stellar/typescript-wallet-sdk/src/walletSdk/Types/auth.ts
+++ b/@stellar/typescript-wallet-sdk/src/walletSdk/Types/auth.ts
@@ -94,6 +94,11 @@ export type SignChallengeTxnParams = {
   challengeTx: string;
   networkPassphrase: string;
   anchorDomain: string;
+  /**
+   * The home domain(s) the challenge is expected to be scoped to. Defaults to
+   * `anchorDomain`. Pass an array for anchors that serve multiple home domains.
+   */
+  homeDomain?: string | string[];
 };
 
 export type SignChallengeTxnResponse = {

--- a/@stellar/typescript-wallet-sdk/test/server.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/server.test.ts
@@ -259,6 +259,24 @@ describe("signChallengeTransaction validation", () => {
     ).rejects.toThrow(ChallengeValidationFailedError);
   });
 
+  it("should wrap a malformed WEB_AUTH_ENDPOINT as a validation failure", async () => {
+    sinon.restore();
+    sinon.stub(StellarToml.Resolver, "resolve").resolves({
+      SIGNING_KEY: anchorAKp.publicKey(),
+      WEB_AUTH_ENDPOINT: "not a url",
+      DOCUMENTATION: {},
+    } as StellarToml.Api.StellarToml);
+
+    await expect(
+      Server.signChallengeTransaction({
+        accountKp,
+        challengeTx: buildChallenge(anchorAKp, anchorA, accountKp.publicKey),
+        networkPassphrase,
+        anchorDomain: anchorA,
+      }),
+    ).rejects.toThrow(ChallengeValidationFailedError);
+  });
+
   it("should accept an explicit homeDomain that differs from anchorDomain", async () => {
     const homeDomain = "wallet-home.example.com";
     const challengeTx = buildChallenge(

--- a/@stellar/typescript-wallet-sdk/test/server.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/server.test.ts
@@ -4,6 +4,7 @@ import {
   Account,
   Asset,
   Keypair,
+  MuxedAccount,
   Operation,
   StellarToml,
   Transaction,
@@ -175,6 +176,47 @@ describe("signChallengeTransaction validation", () => {
         anchorDomain: anchorA,
       }),
     ).rejects.toThrow(ChallengeValidationFailedError);
+  });
+
+  it("should sign a challenge issued for a muxed account of the signing key", async () => {
+    // readChallengeTx returns the M... source verbatim; the underlying G... key
+    // is the correct signer, so this must be accepted.
+    const muxed = new MuxedAccount(
+      new Account(accountKp.publicKey, "0"),
+      "1234",
+    ).accountId();
+    expect(muxed.startsWith("M")).toBe(true);
+
+    const challengeTx = buildChallenge(anchorAKp, anchorA, muxed);
+
+    const signedResp = await Server.signChallengeTransaction({
+      accountKp,
+      challengeTx,
+      networkPassphrase,
+      anchorDomain: anchorA,
+    });
+
+    const signedTxn = TransactionBuilder.fromXDR(
+      signedResp.transaction,
+      networkPassphrase,
+    );
+    expect(signedTxn.signatures.length).toBe(2);
+  });
+
+  it("should reject a muxed challenge whose underlying key is not the signer", async () => {
+    const otherMuxed = new MuxedAccount(
+      new Account(Keypair.random().publicKey(), "0"),
+      "1234",
+    ).accountId();
+
+    await expect(
+      Server.signChallengeTransaction({
+        accountKp,
+        challengeTx: buildChallenge(anchorAKp, anchorA, otherMuxed),
+        networkPassphrase,
+        anchorDomain: anchorA,
+      }),
+    ).rejects.toThrow(ChallengeTxnClientAccountMismatchError);
   });
 
   it("should reject a challenge issued for a different account", async () => {

--- a/@stellar/typescript-wallet-sdk/test/server.test.ts
+++ b/@stellar/typescript-wallet-sdk/test/server.test.ts
@@ -1,6 +1,20 @@
 import axios from "axios";
-import { TransactionBuilder } from "@stellar/stellar-sdk";
+import sinon from "sinon";
+import {
+  Account,
+  Asset,
+  Keypair,
+  Operation,
+  StellarToml,
+  Transaction,
+  TransactionBuilder,
+  WebAuth,
+} from "@stellar/stellar-sdk";
 import { Wallet, Server } from "../src";
+import {
+  ChallengeTxnClientAccountMismatchError,
+  ChallengeValidationFailedError,
+} from "../src/walletSdk/Exceptions";
 
 let wallet;
 let account;
@@ -76,5 +90,149 @@ describe("Server helpers", () => {
     const w2 = `{"id":"d64c5d56-de6d-492e-95dd-412fb86c1c14","kind":"withdrawal","status":"incomplete","amount_in":"0","amount_out":"0","amount_fee":"0","started_at":"2024-03-28T16:18:02Z","stellar_transaction_id":"","refunded":false,"from":"GAZDUFR2L47KHAKX4WSUX3IPZ7462T5E73MAZHXOWOCEBPAQYHT7E62F"}`;
     parsed = Server.parseAnchorTransaction(w2);
     expect(parsed.kind).toBe("withdrawal");
+  });
+});
+
+describe("signChallengeTransaction validation", () => {
+  const anchorA = "anchor-a.example.com";
+  const anchorB = "anchor-b.example.com";
+
+  let anchorAKp;
+  let anchorBKp;
+  let accountKp;
+
+  beforeEach(() => {
+    anchorAKp = Keypair.random();
+    anchorBKp = Keypair.random();
+    accountKp = Wallet.TestNet().stellar().account().createKeypair();
+
+    // anchorDomain always resolves to anchor A's stellar.toml
+    sinon.stub(StellarToml.Resolver, "resolve").resolves({
+      SIGNING_KEY: anchorAKp.publicKey(),
+      WEB_AUTH_ENDPOINT: `https://${anchorA}/auth`,
+      DOCUMENTATION: {},
+    } as StellarToml.Api.StellarToml);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  // webAuthDomain defaults to anchor A, which is what the stubbed
+  // WEB_AUTH_ENDPOINT resolves to for anchorDomain.
+  const buildChallenge = (
+    serverKp,
+    homeDomain,
+    clientAccountID,
+    webAuthDomain = anchorA,
+  ) =>
+    WebAuth.buildChallengeTx(
+      serverKp,
+      clientAccountID,
+      homeDomain,
+      300,
+      networkPassphrase,
+      webAuthDomain,
+    );
+
+  it("should sign a challenge issued by the expected anchor", async () => {
+    const challengeTx = buildChallenge(anchorAKp, anchorA, accountKp.publicKey);
+
+    const signedResp = await Server.signChallengeTransaction({
+      accountKp,
+      challengeTx,
+      networkPassphrase,
+      anchorDomain: anchorA,
+    });
+
+    const signedTxn = TransactionBuilder.fromXDR(
+      signedResp.transaction,
+      networkPassphrase,
+    );
+    expect(signedTxn.signatures.length).toBe(2);
+  });
+
+  it("should reject a challenge issued by a different anchor", async () => {
+    // A relays a challenge that anchor B issued for the same account, ordering
+    // its own signature first so that signatures[0] matches the SIGNING_KEY
+    // published at anchorDomain. Only the home domain, web auth domain and
+    // transaction source bind the challenge to the anchor that issued it.
+    const relayed = TransactionBuilder.fromXDR(
+      buildChallenge(anchorBKp, anchorB, accountKp.publicKey, anchorB),
+      networkPassphrase,
+    ) as Transaction;
+
+    const anchorBSignature = relayed.signatures[0];
+    relayed.signatures.length = 0;
+    relayed.sign(anchorAKp);
+    relayed.signatures.push(anchorBSignature);
+
+    await expect(
+      Server.signChallengeTransaction({
+        accountKp,
+        challengeTx: relayed.toXDR(),
+        networkPassphrase,
+        anchorDomain: anchorA,
+      }),
+    ).rejects.toThrow(ChallengeValidationFailedError);
+  });
+
+  it("should reject a challenge issued for a different account", async () => {
+    const otherAccount = Keypair.random().publicKey();
+    const challengeTx = buildChallenge(anchorAKp, anchorA, otherAccount);
+
+    await expect(
+      Server.signChallengeTransaction({
+        accountKp,
+        challengeTx,
+        networkPassphrase,
+        anchorDomain: anchorA,
+      }),
+    ).rejects.toThrow(ChallengeTxnClientAccountMismatchError);
+  });
+
+  it("should reject a transaction that is not a SEP-10 challenge", async () => {
+    const notAChallenge = new TransactionBuilder(
+      new Account(anchorAKp.publicKey(), "-1"),
+      { fee: "100", networkPassphrase },
+    )
+      .addOperation(
+        Operation.payment({
+          destination: anchorAKp.publicKey(),
+          asset: Asset.native(),
+          amount: "1000",
+        }),
+      )
+      .setTimeout(300)
+      .build();
+    notAChallenge.sign(anchorAKp);
+
+    await expect(
+      Server.signChallengeTransaction({
+        accountKp,
+        challengeTx: notAChallenge.toXDR(),
+        networkPassphrase,
+        anchorDomain: anchorA,
+      }),
+    ).rejects.toThrow(ChallengeValidationFailedError);
+  });
+
+  it("should accept an explicit homeDomain that differs from anchorDomain", async () => {
+    const homeDomain = "wallet-home.example.com";
+    const challengeTx = buildChallenge(
+      anchorAKp,
+      homeDomain,
+      accountKp.publicKey,
+    );
+
+    const signedResp = await Server.signChallengeTransaction({
+      accountKp,
+      challengeTx,
+      networkPassphrase,
+      anchorDomain: anchorA,
+      homeDomain,
+    });
+
+    expect(signedResp.networkPassphrase).toBe(networkPassphrase);
   });
 });


### PR DESCRIPTION
## TL;DR

The server-side SEP-10 challenge signing helper hand-rolled its own challenge validation, checking only that the sequence number was 0 and that the first signature matched the anchor's published signing key. It never confirmed the envelope was actually a SEP-10 challenge, nor that the challenge was scoped to the anchor being authenticated to or issued for the account whose key was about to sign it.

This replaces those two checks with `WebAuth.readChallengeTx` from `@stellar/stellar-sdk` — the same validator the client-side SEP-10 flow and the key manager already use — so all three challenge-signing paths in this repo now validate identically. It also adds an optional expected-home-domain parameter and confirms the challenge was issued for the signing account before signing.

This PR also carries the `4.0.1` release bump for all three packages and their changelogs, so merging it is enough to cut the release without a separate release PR.

<details>
<summary>Implementation details (for agents)</summary>

**What changed:**

- `@stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts` — `signChallengeTransaction()` now resolves the anchor TOML for both `SIGNING_KEY` and `WEB_AUTH_ENDPOINT`, derives `webAuthDomain` from the latter, and delegates validation to `WebAuth.readChallengeTx(challengeTx, signingKey, networkPassphrase, homeDomain ?? anchorDomain, webAuthDomain)`. Failures are wrapped in the existing `ChallengeValidationFailedError`. The returned `clientAccountID` is then compared against `accountKp.publicKey` before signing. The `sequence !== 0` pre-check is kept so `ChallengeTxnIncorrectSequenceError` still surfaces for that case (and so fee-bump envelopes still fail early, since they have no `sequence`).
- `src/walletSdk/Types/auth.ts` — `SignChallengeTxnParams` gains optional `homeDomain?: string | string[]`, defaulting to `anchorDomain`. An array is accepted for anchors serving multiple home domains.
- `src/walletSdk/Exceptions/index.ts` — adds `ChallengeTxnClientAccountMismatchError`.
- `test/server.test.ts` — five offline tests covering the new behaviour.
- All three packages bumped `4.0.0` -> `4.0.1` with changelog entries, following the same file set as #246. `-km` and `-soroban` have no shipped changes and are bumped to stay in lockstep. No lockfile change: the cross-package devDependency is `*`.

**Permalinks:**

- [`Server/index.ts` — `signChallengeTransaction()`](https://github.com/stellar/typescript-wallet-sdk/blob/646f32681140a3e02530073d4f1dd82c842b981f/%40stellar/typescript-wallet-sdk/src/walletSdk/Server/index.ts#L30-L101)
- [`Types/auth.ts` — `SignChallengeTxnParams`](https://github.com/stellar/typescript-wallet-sdk/blob/646f32681140a3e02530073d4f1dd82c842b981f/%40stellar/typescript-wallet-sdk/src/walletSdk/Types/auth.ts#L92-L102)
- [`Exceptions/index.ts` — `ChallengeTxnClientAccountMismatchError`](https://github.com/stellar/typescript-wallet-sdk/blob/646f32681140a3e02530073d4f1dd82c842b981f/%40stellar/typescript-wallet-sdk/src/walletSdk/Exceptions/index.ts#L322-L333)
- [`test/server.test.ts` — new tests](https://github.com/stellar/typescript-wallet-sdk/blob/646f32681140a3e02530073d4f1dd82c842b981f/%40stellar/typescript-wallet-sdk/test/server.test.ts#L96-L238)

**What `readChallengeTx` adds over the previous checks:** transaction source must be the anchor's `SIGNING_KEY`; the first operation must be `manageData` named `<home domain> auth` sourced by the client account; any `web_auth_domain` operation must match the anchor's own web auth domain; the nonce must be 48 bytes; time bounds must be current; remaining operations must be `manageData` with an expected source. It also scans *all* signatures for the server's, rather than only `signatures[0]`.

**Behaviour change worth flagging in review:** a bad server signature previously threw `ChallengeTxnInvalidSignatureError` and now surfaces as `ChallengeValidationFailedError` wrapping the underlying reason. The class is still exported, so nothing breaks at build time, but an integrator catching it specifically would need to widen. Happy to keep throwing the narrower type instead if reviewers prefer.

**Verification:**

- `yarn lint` — clean.
- `yarn workspace @stellar/typescript-wallet-sdk build` — compiles.
- The five new tests stub `StellarToml.Resolver.resolve` with sinon and build challenges with `WebAuth.buildChallengeTx`, so they need no network: signs a challenge from the expected anchor; rejects one issued by a different anchor; rejects one issued for a different account; rejects a `payment` transaction that is not a challenge; accepts an explicit `homeDomain` that differs from `anchorDomain`.
- The cross-anchor test is a true regression test, not just a happy-path inversion: it reorders the relayed envelope's signatures so `signatures[0]` is the expected anchor's. I verified that the previous implementation's check (`anchorKp.verify(tx.hash(), tx.signatures[0].signature())`) **accepts** that input, so the test would have passed before this change and fails without it.

**Follow-ups / out of scope:**

- `webAuthDomain` falls back to `anchorDomain` when the TOML omits `WEB_AUTH_ENDPOINT`. Any anchor serving SEP-10 should publish it, but the fallback avoids breaking integrators whose anchors don't. Making it required could be a follow-up.
- The reference `examples/sep10/sep10Server.ts` still hand-rolls its own sequence check and does not use this helper. Worth aligning separately.
- `homeDomain` is optional here for compatibility. Making it required would be a stronger contract and a candidate for the next major.

</details>
